### PR TITLE
fix(react-utils): don't move focus to first item until menu is rendered

### DIFF
--- a/packages/react-utils/src/hooks/menu/useMenuInteraction.ts
+++ b/packages/react-utils/src/hooks/menu/useMenuInteraction.ts
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -19,6 +20,7 @@ const triggerExpanded = 'aria-expanded'
 
 export function useMenuInteraction() {
   const [expanded, setExpanded] = useState(false)
+  const [focusOnExpand, setFocusOnExpand] = useState(false)
   const menuRef = useRef<HTMLMenuElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
 
@@ -63,7 +65,7 @@ export function useMenuInteraction() {
 
   const openMenuWithFocus = useCallback(() => {
     openMenu()
-    focusFirstItem()
+    setFocusOnExpand(true)
   }, [openMenu])
 
   const handleMenuTriggerKeypress = useCallback(
@@ -135,6 +137,13 @@ export function useMenuInteraction() {
     },
     [closeMenu]
   )
+
+  useEffect(() => {
+    if (expanded && focusOnExpand) {
+      focusFirstItem()
+      setFocusOnExpand(false)
+    }
+  }, [expanded, focusOnExpand])
 
   return useMemo(
     () => ({

--- a/packages/react-utils/src/hooks/menu/useSubmenuInteraction.ts
+++ b/packages/react-utils/src/hooks/menu/useSubmenuInteraction.ts
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -19,6 +20,7 @@ const triggerExpanded = 'aria-expanded'
 
 export function useSubmenuInteraction() {
   const [expanded, setExpanded] = useState(false)
+  const [focusOnExpand, setFocusOnExpand] = useState(false)
   const menuRef = useRef<HTMLMenuElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
 
@@ -45,19 +47,12 @@ export function useSubmenuInteraction() {
     lastItem.focus()
   }
 
-  // function setExpandedAttributes(value: boolean) {
-  //   menuRef.current?.setAttribute(menuExpanded, value.toString())
-  //   triggerRef.current?.setAttribute(triggerExpanded, value.toString())
-  // }
-
   const openMenu = useCallback(() => {
     setExpanded(true)
-    // setExpandedAttributes(true)
   }, [])
 
   const closeMenu = useCallback(() => {
     setExpanded(false)
-    // setExpandedAttributes(false)
   }, [])
 
   const toggleMenu = useCallback(() => {
@@ -70,12 +65,12 @@ export function useSubmenuInteraction() {
 
   const openMenuWithFocus = useCallback(() => {
     openMenu()
-    focusFirstItem()
+    setFocusOnExpand(true)
   }, [openMenu])
 
   const toggleMenuWithFocus = useCallback(() => {
     toggleMenu()
-    focusFirstItem()
+    setFocusOnExpand(true)
   }, [toggleMenu])
 
   const handleSubmenuTriggerKeypress = useCallback(
@@ -160,6 +155,13 @@ export function useSubmenuInteraction() {
     },
     [closeMenu]
   )
+
+  useEffect(() => {
+    if (expanded && focusOnExpand) {
+      focusFirstItem()
+      setFocusOnExpand(false)
+    }
+  }, [expanded, focusOnExpand])
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #962 

## What is the new behavior?
Resolves error by moving focus after menu is rendered

## Other information
