### PR TITLE
Fix/1038 parentless pseudo class in js

### DIFF
--- a/packages/headless-styles/sandbox/plugins/css-to-ts/convert-rules/standard.js
+++ b/packages/headless-styles/sandbox/plugins/css-to-ts/convert-rules/standard.js
@@ -42,9 +42,11 @@ const standard = (rule, result) => {
       if (name) {
         retObj = addProperty(result, name, pseudoObj)
       } else {
+        const pseudoSelectorWithoutColon = pseudoSelector.replace(/^:+/, '')
+
         retObj = addProperty(
           result,
-          `${pseudoSelector}${secondarySelector}`,
+          `${pseudoSelectorWithoutColon}${secondarySelector}`,
           obj
         )
       }

--- a/packages/headless-styles/sandbox/plugins/css-to-ts/convert-rules/standard.js
+++ b/packages/headless-styles/sandbox/plugins/css-to-ts/convert-rules/standard.js
@@ -38,7 +38,16 @@ const standard = (rule, result) => {
       pseudoObj[`&${pseudoSelector}${secondarySelector}`] = obj
 
       name = sanitize(primarySelector.trim())
-      retObj = addProperty(result, name, pseudoObj)
+
+      if (name) {
+        retObj = addProperty(result, name, pseudoObj)
+      } else {
+        retObj = addProperty(
+          result,
+          `${pseudoSelector}${secondarySelector}`,
+          obj
+        )
+      }
     } else if (attributeSelectorIndex !== -1 && attributeSelectorIndex > 0) {
       // Split selector
       const primarySelector = selector.slice(0, attributeSelectorIndex)

--- a/packages/headless-styles/src/components/ConfirmDialog/confirmDialogJS.ts
+++ b/packages/headless-styles/src/components/ConfirmDialog/confirmDialogJS.ts
@@ -12,7 +12,7 @@ export function getJSConfirmDialogProps(options?: ConfirmDialogOptions) {
   const props = createConfirmDialogProps(defaultOptions)
   const backdropStyles = {
     ...styles.confirmDialogBackdrop,
-    background: styles['']['&:root']['--ps-backdrop'],
+    background: styles[':root']['--ps-backdrop'],
   }
   const btnGroupStyles = {
     ...styles.confirmDialogBtnGroup,

--- a/packages/headless-styles/src/components/ConfirmDialog/confirmDialogJS.ts
+++ b/packages/headless-styles/src/components/ConfirmDialog/confirmDialogJS.ts
@@ -12,7 +12,7 @@ export function getJSConfirmDialogProps(options?: ConfirmDialogOptions) {
   const props = createConfirmDialogProps(defaultOptions)
   const backdropStyles = {
     ...styles.confirmDialogBackdrop,
-    background: styles[':root']['--ps-backdrop'],
+    background: styles.root['--ps-backdrop'],
   }
   const btnGroupStyles = {
     ...styles.confirmDialogBtnGroup,

--- a/packages/headless-styles/src/components/ConfirmDialog/generated/confirmDialogCSS.module.ts
+++ b/packages/headless-styles/src/components/ConfirmDialog/generated/confirmDialogCSS.module.ts
@@ -16,10 +16,8 @@ export default {
       },
     },
   },
-  '': {
-    '&:root': {
-      '--ps-backdrop': 'rgba(0 0 0 / 65%)',
-    },
+  ':root': {
+    '--ps-backdrop': 'rgba(0 0 0 / 65%)',
   },
   html: {
     "&[data-theme='light']": {

--- a/packages/headless-styles/src/components/ConfirmDialog/generated/confirmDialogCSS.module.ts
+++ b/packages/headless-styles/src/components/ConfirmDialog/generated/confirmDialogCSS.module.ts
@@ -16,7 +16,7 @@ export default {
       },
     },
   },
-  ':root': {
+  root: {
     '--ps-backdrop': 'rgba(0 0 0 / 65%)',
   },
   html: {

--- a/packages/headless-styles/src/components/Input/generated/inputCSS.module.ts
+++ b/packages/headless-styles/src/components/Input/generated/inputCSS.module.ts
@@ -56,7 +56,7 @@ export default {
       cursor: 'not-allowed',
     },
   },
-  '::placeholder': {
+  placeholder: {
     color: 'var(--ps-text-weak)',
     opacity: '1',
   },

--- a/packages/headless-styles/src/components/Input/generated/inputCSS.module.ts
+++ b/packages/headless-styles/src/components/Input/generated/inputCSS.module.ts
@@ -56,11 +56,9 @@ export default {
       cursor: 'not-allowed',
     },
   },
-  '': {
-    '&::placeholder': {
-      color: 'var(--ps-text-weak)',
-      opacity: '1',
-    },
+  '::placeholder': {
+    color: 'var(--ps-text-weak)',
+    opacity: '1',
   },
   inputIcon: {
     display: 'inline-block',

--- a/packages/headless-styles/src/components/Input/generated/inputCSS.module.ts
+++ b/packages/headless-styles/src/components/Input/generated/inputCSS.module.ts
@@ -30,6 +30,10 @@ export default {
     transitionDuration: '150ms',
     transitionProperty: 'box-shadow, opacity, transform',
     width: '100%',
+    '&::placeholder': {
+      color: 'var(--ps-text-weak)',
+      opacity: '1',
+    },
     '&:active': {
       boxShadow: 'none',
       outline: 'none',
@@ -55,10 +59,6 @@ export default {
     "&[data-readonly='true']": {
       cursor: 'not-allowed',
     },
-  },
-  placeholder: {
-    color: 'var(--ps-text-weak)',
-    opacity: '1',
   },
   inputIcon: {
     display: 'inline-block',
@@ -106,6 +106,10 @@ export default {
     transitionDuration: '150ms',
     transitionProperty: 'box-shadow, opacity, transform',
     width: '100%',
+    '&::placeholder': {
+      color: 'var(--ps-text-weak)',
+      opacity: '1',
+    },
     '&:active': {
       boxShadow: 'none',
       outline: 'none',
@@ -153,6 +157,10 @@ export default {
     transitionDuration: '150ms',
     transitionProperty: 'box-shadow, opacity, transform',
     width: '100%',
+    '&::placeholder': {
+      color: 'var(--ps-text-weak)',
+      opacity: '1',
+    },
     '&:active': {
       boxShadow: 'none',
       outline: 'none',
@@ -200,6 +208,10 @@ export default {
     transitionDuration: '150ms',
     transitionProperty: 'box-shadow, opacity, transform',
     width: '100%',
+    '&::placeholder': {
+      color: 'var(--ps-text-weak)',
+      opacity: '1',
+    },
     '&:active': {
       boxShadow: 'none',
       outline: 'none',

--- a/packages/headless-styles/src/components/Input/inputCSS.module.css
+++ b/packages/headless-styles/src/components/Input/inputCSS.module.css
@@ -27,7 +27,7 @@
   width: 100%;
 }
 
-::placeholder {
+.defaultInput::placeholder {
   color: var(--ps-text-weak);
   opacity: 1;
 }

--- a/packages/headless-styles/src/components/Input/inputJS.ts
+++ b/packages/headless-styles/src/components/Input/inputJS.ts
@@ -16,9 +16,6 @@ export function getJSInputProps(options?: InputOptions) {
   const jsStyles = {
     ...styles.defaultInput,
     ...styles[`${defaultOptions.size}InputBase`],
-    ['&::placeholder']: {
-      ...styles['::placeholder'],
-    },
     ['&[data-disabled="true"]:hover']: {
       ...styles.defaultInput_data_disabled__true['&:hover'],
     },

--- a/packages/headless-styles/src/components/Input/inputJS.ts
+++ b/packages/headless-styles/src/components/Input/inputJS.ts
@@ -17,7 +17,7 @@ export function getJSInputProps(options?: InputOptions) {
     ...styles.defaultInput,
     ...styles[`${defaultOptions.size}InputBase`],
     ['&::placeholder']: {
-      ...styles['']['&::placeholder'],
+      ...styles['::placeholder'],
     },
     ['&[data-disabled="true"]:hover']: {
       ...styles.defaultInput_data_disabled__true['&:hover'],

--- a/packages/headless-styles/src/components/Modal/chakraModal.ts
+++ b/packages/headless-styles/src/components/Modal/chakraModal.ts
@@ -13,7 +13,7 @@ export const ChakraModal = {
   parts: [...modalParts, ...modalExtend],
   baseStyle: {
     overlay: {
-      background: styles[':root']['--ps-backdrop'],
+      background: styles.root['--ps-backdrop'],
     },
     dialog: {
       ...modalStyles.modalSection,

--- a/packages/headless-styles/src/components/Modal/chakraModal.ts
+++ b/packages/headless-styles/src/components/Modal/chakraModal.ts
@@ -13,7 +13,7 @@ export const ChakraModal = {
   parts: [...modalParts, ...modalExtend],
   baseStyle: {
     overlay: {
-      background: styles['']['&:root']['--ps-backdrop'],
+      background: styles[':root']['--ps-backdrop'],
     },
     dialog: {
       ...modalStyles.modalSection,

--- a/packages/headless-styles/src/components/Modal/modalJS.ts
+++ b/packages/headless-styles/src/components/Modal/modalJS.ts
@@ -10,7 +10,7 @@ export function getJSModalProps(options?: ModalOptions) {
   const combinedStyles = {
     backdrop: {
       ...styles.confirmDialogBackdrop,
-      background: styles['']['&:root']['--ps-backdrop'],
+      background: styles[':root']['--ps-backdrop'],
     },
     heading: {
       ...styles.confirmDialogHeader,

--- a/packages/headless-styles/src/components/Modal/modalJS.ts
+++ b/packages/headless-styles/src/components/Modal/modalJS.ts
@@ -10,7 +10,7 @@ export function getJSModalProps(options?: ModalOptions) {
   const combinedStyles = {
     backdrop: {
       ...styles.confirmDialogBackdrop,
-      background: styles[':root']['--ps-backdrop'],
+      background: styles.root['--ps-backdrop'],
     },
     heading: {
       ...styles.confirmDialogHeader,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #1038 

## What is the new behavior?
Pseudo-classes at the root level are no longer nested under an empty property in the resulting JS object.
Prefixed colons are removed from the property in the JS object

### Example: ConfirmDialog.module.ts

#### Before

```javascript
{
  '': {
    '&:root': {
      '--ps-backdrop': 'rgba(0 0 0 / 65%)',
    }
  }
}
```

#### After

```javascript
{
  'root': {
    '--ps-backdrop': 'rgba(0 0 0 / 65%)',
  }
}
```

## Other information
