### PR TITLE
fix(headless-styles): move a11yProps into option prop for consistency

### DIFF
--- a/packages/headless-styles/src/components/Select/selectJS.ts
+++ b/packages/headless-styles/src/components/Select/selectJS.ts
@@ -49,8 +49,8 @@ export function getJSSelectOptionProps(options?: SelectOptionOptions) {
   const props = createSelectOptionProps(defaultOptions)
 
   return {
-    a11yProps: { ...props },
     option: {
+      a11yProps: { ...props },
       ...createJSProps(styles.selectOption),
     },
   }

--- a/packages/headless-styles/tests/select/selectJS.test.ts
+++ b/packages/headless-styles/tests/select/selectJS.test.ts
@@ -36,7 +36,7 @@ describe('Select JS', () => {
     test('should accept a value', () => {
       const optionValue = 'test value'
       expect(
-        getJSSelectOptionProps({ value: optionValue }).a11yProps.value
+        getJSSelectOptionProps({ value: optionValue }).option.a11yProps.value
       ).toEqual(optionValue)
     })
   })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #1026 

## What is the new behavior?
Moves Select Option a11yProps under `option` prop for consistency with other JS APIs

## Other information
