### PR TITLE
Fix/1001 camelcase warnings

### DIFF
--- a/packages/headless-styles/sandbox/plugins/css-to-ts/convert-rules/standard.js
+++ b/packages/headless-styles/sandbox/plugins/css-to-ts/convert-rules/standard.js
@@ -35,7 +35,8 @@ const standard = (rule, result) => {
       )
 
       const pseudoObj = {}
-      pseudoObj[`&${pseudoSelector}${secondarySelector}`] = obj
+      pseudoObj[`&${camelize(pseudoSelector)}${camelize(secondarySelector)}`] =
+        obj
 
       name = sanitize(primarySelector.trim())
 
@@ -46,7 +47,9 @@ const standard = (rule, result) => {
 
         retObj = addProperty(
           result,
-          `${pseudoSelectorWithoutColon}${secondarySelector}`,
+          `${camelize(pseudoSelectorWithoutColon)}${camelize(
+            secondarySelector
+          )}`,
           obj
         )
       }
@@ -56,7 +59,7 @@ const standard = (rule, result) => {
       const attributeSelector = selector.slice(attributeSelectorIndex)
 
       const attrObj = {}
-      attrObj[`&${attributeSelector}`] = obj
+      attrObj[`&${camelize(attributeSelector)}`] = obj
 
       name = sanitize(primarySelector.trim())
       retObj = addProperty(result, name, attrObj)

--- a/packages/headless-styles/sandbox/src/components/Tabs.jsx
+++ b/packages/headless-styles/sandbox/src/components/Tabs.jsx
@@ -138,7 +138,7 @@ function TabJS(props) {
       style={{
         ...tabPropsJS.tab.styles,
         ...(data['aria-selected'] &&
-          tabPropsJS.tab.styles["&[aria-selected='true']"]),
+          tabPropsJS.tab.styles["&[ariaSelected='true']"]),
         ...(focused && tabPropsJS.tab.styles['&:focus']),
       }}
     >
@@ -147,7 +147,7 @@ function TabJS(props) {
         style={{
           ...tabPropsJS.tab.styles['&::after'],
           ...(data['aria-selected'] &&
-            tabPropsJS.tab.styles["&[aria-selected='true']::after"]),
+            tabPropsJS.tab.styles["&[ariaSelected='true']::after"]),
           ...(hovering && tabPropsJS.tab.styles['&:hover::after']),
         }}
       />
@@ -197,7 +197,7 @@ function TabPanelJS(props) {
       style={{
         ...tabPropsJS.tabPanel.styles,
         ...(data['aria-hidden'] &&
-          tabPropsJS.tabPanel.styles["&[aria-hidden='true']"]),
+          tabPropsJS.tabPanel.styles["&[ariaHidden='true']"]),
       }}
     >
       {data.id}

--- a/packages/headless-styles/src/components/Avatar/generated/avatarCSS.module.ts
+++ b/packages/headless-styles/src/components/Avatar/generated/avatarCSS.module.ts
@@ -21,7 +21,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },
@@ -51,7 +51,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },
@@ -74,7 +74,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Checkbox/chakraCheckbox.ts
+++ b/packages/headless-styles/src/components/Checkbox/chakraCheckbox.ts
@@ -18,7 +18,7 @@ export const ChakraCheckbox = {
         ...styles.checkboxInput['&:focus + .checkboxControl'],
       },
       _checked: {
-        ...styles.checkboxControl["&[data-checked='true']"],
+        ...styles.checkboxControl["&[dataChecked='true']"],
         color: 'white',
         _hover: {
           ...styles.checkboxControl_data_checked__true['&:hover'],
@@ -28,7 +28,7 @@ export const ChakraCheckbox = {
         ...styles.checkboxControl['&[disabled]'],
       },
       _invalid: {
-        ...styles.checkboxControl["&[data-invalid='true']"],
+        ...styles.checkboxControl["&[dataInvalid='true']"],
         _hover: {
           ...styles.checkboxControl_data_invalid__true['&:hover'],
         },

--- a/packages/headless-styles/src/components/Checkbox/checkboxJS.ts
+++ b/packages/headless-styles/src/components/Checkbox/checkboxJS.ts
@@ -8,13 +8,13 @@ export function getJSCheckboxProps(options?: CheckboxOptions) {
   const props = createCheckboxProps(defaultOptions)
   const controlStyles = {
     ...styles.checkboxControl,
-    '&[data-checked="true"]:hover': {
+    '&[dataChecked="true"]:hover': {
       ...styles.checkboxControl_data_checked__true['&:hover'],
     },
-    '&[data-invalid="true"]:hover': {
+    '&[dataInvalid="true"]:hover': {
       ...styles.checkboxControl_data_invalid__true['&:hover'],
     },
-    '&[data-readonly="true"]:hover': {
+    '&[dataReadonly="true"]:hover': {
       ...styles.checkboxControl_data_readonly__true['&:hover'],
     },
   }

--- a/packages/headless-styles/src/components/Checkbox/generated/checkboxCSS.module.ts
+++ b/packages/headless-styles/src/components/Checkbox/generated/checkboxCSS.module.ts
@@ -13,7 +13,7 @@ export default {
     '&[disabled]': {
       cursor: 'not-allowed',
     },
-    "&[data-readonly='true']": {
+    "&[dataReadonly='true']": {
       cursor: 'not-allowed',
     },
   },
@@ -32,7 +32,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible) + .checkboxControl': {
+    '&:focus:not(:focusVisible) + .checkboxControl': {
       boxShadow: 'none',
       outline: 'none',
     },
@@ -60,7 +60,7 @@ export default {
       background: 'var(--ps-background-hover)',
       borderColor: 'var(--ps-background-hover)',
     },
-    "&[data-checked='true']": {
+    "&[dataChecked='true']": {
       background: 'var(--ps-action-background)',
       borderColor: 'var(--ps-action-background)',
     },
@@ -68,7 +68,7 @@ export default {
       background: 'var(--ps-background)',
       borderColor: 'var(--ps-background)',
     },
-    "&[data-invalid='true']": {
+    "&[dataInvalid='true']": {
       background: 'var(--ps-danger-surface)',
       borderColor: 'var(--ps-danger-surface)',
       color: 'var(--ps-danger-text)',

--- a/packages/headless-styles/src/components/ConfirmDialog/generated/confirmDialogCSS.module.ts
+++ b/packages/headless-styles/src/components/ConfirmDialog/generated/confirmDialogCSS.module.ts
@@ -20,7 +20,7 @@ export default {
     '--ps-backdrop': 'rgba(0 0 0 / 65%)',
   },
   html: {
-    "&[data-theme='light']": {
+    "&[dataTheme='light']": {
       '--ps-backdrop': 'rgba(255 255 255 / 65%)',
     },
   },

--- a/packages/headless-styles/src/components/Input/chakraInput.ts
+++ b/packages/headless-styles/src/components/Input/chakraInput.ts
@@ -8,7 +8,7 @@ const chakraInputStyle = {
       ...baseInputStyles['&:focus'],
     },
     _hover: {
-      ...baseInputStyles["&:not(:disabled, [data-readonly='true']):hover"],
+      ...baseInputStyles["&:not(:disabled, [dataReadonly='true']):hover"],
     },
     _focus: {
       ...baseInputStyles['&:focus'],
@@ -20,12 +20,12 @@ const chakraInputStyle = {
       },
     },
     _invalid: {
-      ...baseInputStyles["&[data-invalid='true']"],
+      ...baseInputStyles["&[dataInvalid='true']"],
     },
     _readOnly: {
-      ...baseInputStyles["&:is(:disabled, [data-readonly='true'])"],
+      ...baseInputStyles["&:is(:disabled, [dataReadonly='true'])"],
       _hover: {
-        ...baseInputStyles["&:is(:disabled, [data-readonly='true'])"],
+        ...baseInputStyles["&:is(:disabled, [dataReadonly='true'])"],
       },
     },
   },

--- a/packages/headless-styles/src/components/Input/generated/inputCSS.module.ts
+++ b/packages/headless-styles/src/components/Input/generated/inputCSS.module.ts
@@ -28,7 +28,7 @@ export default {
     top: '50%',
     transform: 'translateY(-50%)',
     zIndex: '50',
-    "&[data-invalid='true']": {
+    "&[dataInvalid='true']": {
       color: 'var(--ps-danger-text-weak)',
     },
   },
@@ -40,7 +40,7 @@ export default {
     top: '50%',
     transform: 'translateY(-50%)',
     zIndex: '50',
-    "&[data-invalid='true']": {
+    "&[dataInvalid='true']": {
       color: 'var(--ps-danger-text-weak)',
     },
     left: '0.798rem',

--- a/packages/headless-styles/src/components/Menu/generated/menuCSS.module.ts
+++ b/packages/headless-styles/src/components/Menu/generated/menuCSS.module.ts
@@ -37,7 +37,7 @@ export default {
     position: 'absolute',
     width: '14rem',
     zIndex: '1000',
-    "&[data-expanded='true']": {
+    "&[dataExpanded='true']": {
       display: 'block',
     },
   },
@@ -86,7 +86,7 @@ export default {
     transition: 'background-color 250ms ease-in-out, color 250ms ease-in-out',
     whiteSpace: 'nowrap',
     width: '100%',
-    '&:any-link': {
+    '&:anyLink': {
       appearance: 'none',
       background: 'transparent',
       border: '0',
@@ -115,10 +115,10 @@ export default {
       top: '0',
       zIndex: '1010',
     },
-    "&[aria-expanded='true'] ~ .menu": {
+    "&[ariaExpanded='true'] ~ .menu": {
       display: 'block',
     },
-    "&[aria-expanded='true']": {
+    "&[ariaExpanded='true']": {
       background: 'var(--ps-action-background)',
       color: 'var(--ps-action-text)',
     },
@@ -126,15 +126,15 @@ export default {
       background: 'var(--ps-action-background)',
       color: 'var(--ps-action-text)',
     },
-    "&:hover:not([aria-expanded='true'])": {
+    "&:hover:not([ariaExpanded='true'])": {
       background: 'var(--ps-background-hover)',
       color: 'var(--ps-text)',
     },
-    "&:focus:not([aria-expanded='true'])": {
+    "&:focus:not([ariaExpanded='true'])": {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Popover/generated/popoverCSS.module.ts
+++ b/packages/headless-styles/src/components/Popover/generated/popoverCSS.module.ts
@@ -16,9 +16,9 @@ export default {
     minWidth: '17.5em',
     textAlign: 'start',
     zIndex: '1500',
-    "&[data-expanded='true']": {
+    "&[dataExpanded='true']": {
       // @ts-ignore
-      ...tooltip.pandoTooltipBase["&[data-expanded='true']"],
+      ...tooltip.pandoTooltipBase["&[dataExpanded='true']"],
       display: 'inline-block',
     },
   },
@@ -114,11 +114,9 @@ export default {
     fontFamily: 'inherit',
     fontSize: 'inherit',
     outline: 'none',
-    "&[aria-expanded='true'] + [data-popover]": {
+    "&[ariaExpanded='true'] + [dataPopover]": {
       // @ts-ignore
-      ...tooltip.pandoTooltipTrigger[
-        "&[aria-expanded='true'] + [data-popover]"
-      ],
+      ...tooltip.pandoTooltipTrigger["&[ariaExpanded='true'] + [dataPopover]"],
       display: 'inline-block',
     },
   },

--- a/packages/headless-styles/src/components/Radio/chakraRadio.ts
+++ b/packages/headless-styles/src/components/Radio/chakraRadio.ts
@@ -18,7 +18,7 @@ export const ChakraRadio = {
         ...styles.radioInput['&:focus + .radioControl'],
       },
       _checked: {
-        ...styles.radioControl["&[data-checked='true']"],
+        ...styles.radioControl["&[dataChecked='true']"],
         _before: {
           ...styles.radioControl_data_checked__true['&::before'],
         },
@@ -30,7 +30,7 @@ export const ChakraRadio = {
         ...styles.radioContainer['&[disabled]'],
       },
       _invalid: {
-        ...styles.radioControl["&[data-invalid='true']"],
+        ...styles.radioControl["&[dataInvalid='true']"],
         _hover: {
           ...styles.radioControl_data_invalid__true['&:hover'],
         },

--- a/packages/headless-styles/src/components/Radio/generated/radioCSS.module.ts
+++ b/packages/headless-styles/src/components/Radio/generated/radioCSS.module.ts
@@ -17,7 +17,7 @@ export default {
     '&[disabled]': {
       cursor: 'not-allowed',
     },
-    "&[data-readonly='true']": {
+    "&[dataReadonly='true']": {
       cursor: 'not-allowed',
     },
   },
@@ -35,7 +35,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible) + .radioControl': {
+    '&:focus:not(:focusVisible) + .radioControl': {
       boxShadow: 'none',
       outline: 'none',
     },
@@ -60,7 +60,7 @@ export default {
     '&:not([disabled]):hover': {
       background: 'var(--ps-background-hover)',
     },
-    "&[data-checked='true']": {
+    "&[dataChecked='true']": {
       background: 'var(--ps-action-background)',
       borderColor: 'var(--ps-action-background)',
       borderWidth: 'initial',
@@ -69,7 +69,7 @@ export default {
       background: 'var(--ps-background)',
       borderColor: 'var(--ps-background)',
     },
-    "&[data-invalid='true']": {
+    "&[dataInvalid='true']": {
       background: 'var(--ps-danger-surface)',
       borderColor: 'var(--ps-danger-surface)',
     },

--- a/packages/headless-styles/src/components/Radio/radioJS.ts
+++ b/packages/headless-styles/src/components/Radio/radioJS.ts
@@ -9,13 +9,13 @@ export function getJSRadioProps(options?: RadioOptions) {
   const props = createCheckboxFieldProps(defaultOptions)
   const controlStyles = {
     ...styles.radioControl,
-    '&[data-checked="true"]:hover': {
+    '&[dataChecked="true"]:hover': {
       ...styles.radioControl_data_checked__true['&:hover'],
     },
-    '&[data-checked="true"]::before': {
+    '&[dataChecked="true"]::before': {
       ...styles.radioControl_data_checked__true['&::before'],
     },
-    '&[data-invalid="true"]:hover': {
+    '&[dataInvalid="true"]:hover': {
       ...styles.radioControl_data_invalid__true['&:hover'],
     },
   }

--- a/packages/headless-styles/src/components/Select/chakraSelect.ts
+++ b/packages/headless-styles/src/components/Select/chakraSelect.ts
@@ -9,7 +9,7 @@ const baseSelectStyles = {
     ...selectBase['&:focus'],
   },
   _hover: {
-    ...selectBase["&:not(:disabled, [data-readonly='true']):hover"],
+    ...selectBase["&:not(:disabled, [dataReadonly='true']):hover"],
   },
   _focus: {
     ...selectBase['&:focus'],
@@ -22,7 +22,7 @@ const baseSelectStyles = {
     },
   },
   _invalid: {
-    ...selectBase["&[data-invalid='true']"],
+    ...selectBase["&[dataInvalid='true']"],
   },
 }
 

--- a/packages/headless-styles/src/components/Switch/chakraSwitch.ts
+++ b/packages/headless-styles/src/components/Switch/chakraSwitch.ts
@@ -13,7 +13,7 @@ const baseTrackStyles = {
   width: mTrackWidth,
 }
 
-const checkedAttr = "&[data-checked='true']"
+const checkedAttr = "&[dataChecked='true']"
 
 export const ChakraSwitch = {
   baseStyle: {
@@ -30,22 +30,22 @@ export const ChakraSwitch = {
     track: {
       ...baseTrackStyles,
       _hover: {
-        ...track["&:not([disabled], [data-readonly='true']):hover"],
+        ...track["&:not([disabled], [dataReadonly='true']):hover"],
       },
       _checked: {
         ...styles.track[checkedAttr],
         _hover: {
-          ...styles.track["&:not([disabled], [data-readonly='true']):hover"],
+          ...styles.track["&:not([disabled], [dataReadonly='true']):hover"],
         },
       },
       _disabled: {
-        ...styles.track["&:is([disabled], [data-readonly='true'])"],
+        ...styles.track["&:is([disabled], [dataReadonly='true'])"],
         _hover: {
-          ...styles.track["&:is([disabled], [data-readonly='true'])"],
+          ...styles.track["&:is([disabled], [dataReadonly='true'])"],
         },
       },
       _invalid: {
-        ...styles.track["&[data-invalid='true']"],
+        ...styles.track["&[dataInvalid='true']"],
         _hover: {
           ...styles.track_data_invalid__true['&:hover'],
         },

--- a/packages/headless-styles/src/components/Switch/generated/switchCSS.module.ts
+++ b/packages/headless-styles/src/components/Switch/generated/switchCSS.module.ts
@@ -29,7 +29,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible) + .track': {
+    '&:focus:not(:focusVisible) + .track': {
       boxShadow: 'none',
       outline: 'none',
     },
@@ -41,7 +41,7 @@ export default {
     transitionDuration: '200ms',
     transitionProperty: 'transform',
     width: 'var(--ps-thumb-size)',
-    "&[data-checked='true']": {
+    "&[dataChecked='true']": {
       transform:
         'translateX(calc(var(--ps-track-width) - var(--ps-track-height)))',
     },
@@ -62,21 +62,21 @@ export default {
     transitionDuration: '150ms',
     transitionProperty: 'background, background-color, border-color, transform',
     width: 'var(--ps-track-width)',
-    "&:is([disabled], [data-readonly='true'])": {
+    "&:is([disabled], [dataReadonly='true'])": {
       cursor: 'not-allowed',
     },
-    "&:not([disabled], [data-readonly='true']):hover": {
+    "&:not([disabled], [dataReadonly='true']):hover": {
       background: 'var(--ps-background-hover)',
     },
-    "&[data-checked='true']": {
+    "&[dataChecked='true']": {
       background: 'var(--ps-action-background)',
     },
-    "&[data-invalid='true']": {
+    "&[dataInvalid='true']": {
       background: 'var(--ps-danger-surface)',
     },
   },
   track_data_checked__true: {
-    "&:not([disabled], [data-readonly='true']):hover": {
+    "&:not([disabled], [dataReadonly='true']):hover": {
       background: 'var(--ps-action-background-hover)',
     },
   },
@@ -101,16 +101,16 @@ export default {
     transitionDuration: '150ms',
     transitionProperty: 'background, background-color, border-color, transform',
     width: 'var(--ps-track-width)',
-    "&:is([disabled], [data-readonly='true'])": {
+    "&:is([disabled], [dataReadonly='true'])": {
       cursor: 'not-allowed',
     },
-    "&:not([disabled], [data-readonly='true']):hover": {
+    "&:not([disabled], [dataReadonly='true']):hover": {
       background: 'var(--ps-background-hover)',
     },
-    "&[data-checked='true']": {
+    "&[dataChecked='true']": {
       background: 'var(--ps-action-background)',
     },
-    "&[data-invalid='true']": {
+    "&[dataInvalid='true']": {
       background: 'var(--ps-danger-surface)',
     },
   },
@@ -130,16 +130,16 @@ export default {
     transitionDuration: '150ms',
     transitionProperty: 'background, background-color, border-color, transform',
     width: 'var(--ps-track-width)',
-    "&:is([disabled], [data-readonly='true'])": {
+    "&:is([disabled], [dataReadonly='true'])": {
       cursor: 'not-allowed',
     },
-    "&:not([disabled], [data-readonly='true']):hover": {
+    "&:not([disabled], [dataReadonly='true']):hover": {
       background: 'var(--ps-background-hover)',
     },
-    "&[data-checked='true']": {
+    "&[dataChecked='true']": {
       background: 'var(--ps-action-background)',
     },
-    "&[data-invalid='true']": {
+    "&[dataInvalid='true']": {
       background: 'var(--ps-danger-surface)',
     },
   },

--- a/packages/headless-styles/src/components/Tabs/generated/tabsCSS.module.ts
+++ b/packages/headless-styles/src/components/Tabs/generated/tabsCSS.module.ts
@@ -20,7 +20,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },
@@ -59,14 +59,14 @@ export default {
     '&:hover::after': {
       height: '0.25rem',
     },
-    "&[aria-selected='true']": {
+    "&[ariaSelected='true']": {
       color: 'var(--ps-action-text-inverse)',
     },
     '&:focus': {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },
@@ -105,14 +105,14 @@ export default {
     '&:hover::after': {
       height: '0.25rem',
     },
-    "&[aria-selected='true']": {
+    "&[ariaSelected='true']": {
       color: 'var(--ps-action-text-inverse)',
     },
     '&:focus': {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },
@@ -151,14 +151,14 @@ export default {
     '&:hover::after': {
       height: '0.25rem',
     },
-    "&[aria-selected='true']": {
+    "&[ariaSelected='true']": {
       color: 'var(--ps-action-text-inverse)',
     },
     '&:focus': {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },
@@ -172,14 +172,14 @@ export default {
   tabPanel: {
     borderRadius: '6px',
     width: '100%',
-    "&[aria-hidden='true']": {
+    "&[ariaHidden='true']": {
       display: 'none',
     },
     '&:focus': {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Tabs/tabsJS.ts
+++ b/packages/headless-styles/src/components/Tabs/tabsJS.ts
@@ -35,7 +35,7 @@ export function getJSTabsProps(options?: TabsOptions) {
     tab: {
       ...styles.tabBase,
       ...styles[sizeClass],
-      "&[aria-selected='true']::after":
+      "&[ariaSelected='true']::after":
         styles.tabBase_aria_selected__true['&::after'],
     },
     tabPanel: {

--- a/packages/headless-styles/src/components/Tag/generated/tagCSS.module.ts
+++ b/packages/headless-styles/src/components/Tag/generated/tagCSS.module.ts
@@ -45,7 +45,7 @@ export default {
       color: 'var(--ps-action-navigation-visited)',
       outline: 'none',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       color: 'var(--ps-action-navigation-visited)',
       outline: 'none',
@@ -92,7 +92,7 @@ export default {
       color: 'var(--ps-action-navigation-visited)',
       outline: 'none',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       color: 'var(--ps-action-navigation-visited)',
       outline: 'none',
@@ -139,7 +139,7 @@ export default {
       color: 'var(--ps-action-navigation-visited)',
       outline: 'none',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       color: 'var(--ps-action-navigation-visited)',
       outline: 'none',

--- a/packages/headless-styles/src/components/TextLink/generated/textLinkCSS.module.ts
+++ b/packages/headless-styles/src/components/TextLink/generated/textLinkCSS.module.ts
@@ -28,7 +28,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Textarea/chakraTextarea.ts
+++ b/packages/headless-styles/src/components/Textarea/chakraTextarea.ts
@@ -8,7 +8,7 @@ const chakraTextareaStyle = {
     ...baseTextareaStyles['&:focus'],
   },
   _hover: {
-    ...baseTextareaStyles["&:not(:disabled, [data-readonly='true']):hover"],
+    ...baseTextareaStyles["&:not(:disabled, [dataReadonly='true']):hover"],
   },
   _focus: {
     ...baseTextareaStyles['&:focus'],
@@ -21,12 +21,12 @@ const chakraTextareaStyle = {
     },
   },
   _invalid: {
-    ...styles.textareaBase["&[data-invalid='true']"],
+    ...styles.textareaBase["&[dataInvalid='true']"],
   },
   _readOnly: {
-    ...styles.textareaBase["&:is(:disabled, [data-readonly='true'])"],
+    ...styles.textareaBase["&:is(:disabled, [dataReadonly='true'])"],
     _hover: {
-      ...styles.textareaBase["&:is(:disabled, [data-readonly='true'])"],
+      ...styles.textareaBase["&:is(:disabled, [dataReadonly='true'])"],
     },
   },
 }

--- a/packages/headless-styles/src/components/shared/generated/input.module.ts
+++ b/packages/headless-styles/src/components/shared/generated/input.module.ts
@@ -36,21 +36,21 @@ export default {
       background: 'var(--ps-background)',
       borderColor: 'var(--ps-background)',
     },
-    "&:is(:disabled, [data-readonly='true'])": {
+    "&:is(:disabled, [dataReadonly='true'])": {
       // @ts-ignore
-      ...states.pandoDefaultStates["&:is(:disabled, [data-readonly='true'])"],
+      ...states.pandoDefaultStates["&:is(:disabled, [dataReadonly='true'])"],
       cursor: 'not-allowed',
     },
-    "&:not(:disabled, [data-readonly='true']):hover": {
+    "&:not(:disabled, [dataReadonly='true']):hover": {
       // @ts-ignore
       ...states.pandoDefaultStates[
-        "&:not(:disabled, [data-readonly='true']):hover"
+        "&:not(:disabled, [dataReadonly='true']):hover"
       ],
       boxShadow: 'var(--ps-border-strong) 0 0 0 1px',
     },
-    "&[data-invalid='true']": {
+    "&[dataInvalid='true']": {
       // @ts-ignore
-      ...states.pandoDefaultStates["&[data-invalid='true']"],
+      ...states.pandoDefaultStates["&[dataInvalid='true']"],
       borderColor: 'var(--ps-danger-border)',
       boxShadow: 'var(--ps-danger-border) 0 0 0 1px',
     },

--- a/packages/headless-styles/src/components/shared/generated/states.module.ts
+++ b/packages/headless-styles/src/components/shared/generated/states.module.ts
@@ -15,7 +15,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/shared/generated/tooltip.module.ts
+++ b/packages/headless-styles/src/components/shared/generated/tooltip.module.ts
@@ -10,7 +10,7 @@ export default {
   pandoTooltipWrapper: {
     display: 'inline-block',
     position: 'relative',
-    '&:is(:hover, :focus-within)\n  > [data-tooltip]:not([disabled])': {
+    '&:is(:hover, :focusWithin)\n  > [dataTooltip]:not([disabled])': {
       display: 'inline-block',
     },
   },

--- a/packages/headless-styles/src/utils/helpers.ts
+++ b/packages/headless-styles/src/utils/helpers.ts
@@ -8,7 +8,7 @@ import type {
 
 function formatCSSPropName(propName: string) {
   if (propName.includes('&')) {
-    return propName
+    return `${kebabCase(propName)}`
   }
 
   return `${kebabCase(propName)}:`


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
contributes to #1001 by addressing React console warnings

## What is the new behavior?
Warnings are no longer displayed when assigning `styles` object to the `style` prop
Converts hyphenated selectors in nested styles to camelCase
Camel Case selectors are then converted back to kebab case for `cssProps` string
Updates references to the changed selectors in JS APIs

## Other information
Will require instructions that the `styles` object won't work directly with styled-components and others (emotion), and that only `cssProps` should be used.
