### PR TITLE
1068 bug preloading font script in safari

### DIFF
--- a/packages/design-tokens/fonts.css
+++ b/packages/design-tokens/fonts.css
@@ -1,35 +1,19 @@
 @font-face {
   font-display: swap;
-  font-family: 'PS TT Commons Roman';
-  font-weight: 400 600;
+  font-family: 'PS Commons';
+  font-style: normal;
+  font-weight: 500 800;
   src: url('https://fonts.pluralsight.com/ps-tt-commons/v1/ps-tt-commons-variable-roman.woff2')
     format('woff-variations');
 }
 
 @font-face {
   font-display: swap;
-  font-family: 'PS TT Commons Roman';
+  font-family: 'PS Commons Italic';
   font-style: italic;
+  font-weight: 500 800;
   src: url('https://fonts.pluralsight.com/ps-tt-commons/v1/ps-tt-commons-variable-italic.woff2')
     format('woff-variations');
-}
-
-@font-face {
-  font-display: swap;
-  font-family: 'DM Mono';
-  font-style: normal;
-  font-weight: 300;
-  src: url('https://fonts.pluralsight.com/dm-mono/v1/dm-mono-light.ttf')
-    format('truetype');
-}
-
-@font-face {
-  font-display: swap;
-  font-family: 'DM Mono';
-  font-style: italic;
-  font-weight: 300;
-  src: url('https://fonts.pluralsight.com/dm-mono/v1/dm-mono-light-italic.ttf')
-    format('truetype');
 }
 
 @font-face {
@@ -43,27 +27,9 @@
 
 @font-face {
   font-display: swap;
-  font-family: 'DM Mono';
-  font-style: italic;
-  font-weight: 400;
-  src: url('https://fonts.pluralsight.com/dm-mono/v1/dm-mono-italic.ttf')
-    format('truetype');
-}
-
-@font-face {
-  font-display: swap;
-  font-family: 'DM Mono';
+  font-family: 'DM Mono Strong';
   font-style: normal;
   font-weight: 500;
   src: url('https://fonts.pluralsight.com/dm-mono/v1/dm-mono-medium.ttf')
-    format('truetype');
-}
-
-@font-face {
-  font-display: swap;
-  font-family: 'DM Mono';
-  font-style: italic;
-  font-weight: 500;
-  src: url('https://fonts.pluralsight.com/dm-mono/v1/dm-mono-medium-italic.ttf')
     format('truetype');
 }

--- a/packages/design-tokens/styles/_core.scss
+++ b/packages/design-tokens/styles/_core.scss
@@ -4,12 +4,10 @@ html {
   background-color: var(--ps-surface);
   box-sizing: border-box;
   color: var(--ps-text);
-  font-family: 'PS TT Commons Roman', 'Gotham SSm A', 'Gotham SSm B', Arial,
-    sans-serif;
+  font-family: 'PS Commons', 'Gotham SSm A', 'Gotham SSm B', Arial, sans-serif;
   font-feature-settings: 'tnum' on, 'lnum' on;
   font-size: 1em;
   -webkit-font-smoothing: antialiased;
-  font-variation-settings: 'wght' 500;
   font-weight: 500;
   line-height: 1.5;
   scroll-behavior: smooth;

--- a/packages/design-tokens/styles/_typography.scss
+++ b/packages/design-tokens/styles/_typography.scss
@@ -1,5 +1,4 @@
 :is(h1, h2, h3, h4, h5, h6) {
-  font-variation-settings: 'wght' 600;
   font-weight: 600;
 }
 
@@ -8,7 +7,6 @@
 }
 
 :is(h4, h5, h6, strong) {
-  font-variation-settings: 'wght' 700;
   font-weight: 700;
 }
 
@@ -39,14 +37,24 @@ h6 {
 }
 
 .black-heading {
-  font-variation-settings: 'wght' 800;
   font-weight: 800;
+}
+
+.display-l {
+  font-size: 5.5rem;
+}
+
+.display-m {
+  font-size: 4.5rem;
+}
+
+.display-s {
+  font-size: 3.5rem;
 }
 
 // body
 
 :is(small, p) {
-  font-variation-settings: 'wght' 500;
   font-weight: 500;
 }
 
@@ -72,6 +80,17 @@ p.size-xl {
 
 p.size-xxl {
   font-size: 1.5rem;
+}
+
+em {
+  font-family: 'PS Commons Italic';
+}
+
+// forms
+
+label {
+  font-size: 0.875rem;
+  font-weight: 700;
 }
 
 // code
@@ -101,12 +120,6 @@ mark::after {
   position: absolute;
   white-space: nowrap;
   width: 1px;
-}
-
-label {
-  font-size: 0.875rem;
-  font-variation-settings: 'wght' 700;
-  font-weight: 700;
 }
 
 mark::before {

--- a/website/docs/development/getting-started/installation.md
+++ b/website/docs/development/getting-started/installation.md
@@ -42,9 +42,9 @@ Pluralsight Design is developed with a mobile-first strategy in which we first w
 <meta name="viewport" content="initial-scale=1, width=device-width" />
 ```
 
-## PS TT Commons font
+## PS Commons font
 
-Our packages were developed with PS TT Commons (Pluralsight brand font) in mind. For the best results, install via an HTML `link` tag in your `head` element:
+Our packages were developed with PS Commons (Pluralsight brand font) in mind. For the best results, install via an HTML `link` tag in your `head` element:
 
 ```html
 <link
@@ -85,7 +85,7 @@ To add the normalize file, simply copy and paste the `link` content below into y
 
 ### Using custom fonts
 
-Not interested in using the PS TT Commons font? Simply leave out the [font imports](#ps-tt-commons-font) and instead use your own font declaration for the `html` element.
+Not interested in using the PS TT Commons font? Simply leave out the [font imports](#ps-commons-font) and instead use your own font declaration for the `html` element.
 
 ```css title="Example of using a custom font"
 html {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -35,6 +35,33 @@ const config = {
   organizationName: 'pluralsight',
   projectName: 'pando',
 
+  headTags: [
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preload',
+        href: 'https://fonts.pluralsight.com/ps-tt-commons/v1/ps-tt-commons-variable-roman.woff2',
+        as: 'font',
+        type: 'font/woff2',
+        crossorigin: 'anonymous',
+      },
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'stylesheet',
+        href: 'https://cdn.jsdelivr.net/npm/@pluralsight/design-tokens@next/fonts.css',
+      },
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'stylesheet',
+        href: 'https://cdn.jsdelivr.net/npm/@pluralsight/design-tokens@next/npm/normalize/normalize.css',
+      },
+    },
+  ],
+
   presets: [
     [
       '@docusaurus/preset-classic',

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,6 +1,3 @@
-@import url('https://cdn.jsdelivr.net/npm/@pluralsight/design-tokens@next/fonts.css');
-@import url('https://cdn.jsdelivr.net/npm/@pluralsight/design-tokens@0.3.1-rc-124083/npm/normalize/normalize.css');
-
 :root {
   --docusaurus-highlighted-code-line-bg: #061c32;
   --ifm-background-color: var(--ps-surface);
@@ -81,10 +78,8 @@ html[data-theme='light'] {
 html {
   background-color: var(--ps-surface);
   color: var(--ps-text);
-  font-family: 'PS TT Commons Roman', 'Gotham SSm A', 'Gotham SSm B', Arial,
-    sans-serif;
+  font-family: 'PS Commons', 'Gotham SSm A', 'Gotham SSm B', Arial, sans-serif;
   font-size: 1em;
-  font-variation-settings: 'wght' 500;
   font-weight: 500;
   line-height: 1.5;
   text-rendering: geometricPrecision;
@@ -95,7 +90,6 @@ html {
 /* typography */
 
 :is(h1, h2, h3, h4, h5, h6) {
-  font-variation-settings: 'wght' 600;
   font-weight: 600;
 }
 
@@ -112,7 +106,6 @@ html {
 }
 
 .black-heading {
-  font-variation-settings: 'wght' 800;
   font-weight: 800;
 }
 
@@ -273,7 +266,6 @@ div[role='banner'] {
 
 .navbar__title {
   font-size: 0.75rem;
-  font-variation-settings: 'wght' 700;
   font-weight: 700;
   letter-spacing: 3px;
   text-transform: uppercase;
@@ -321,7 +313,6 @@ div[role='banner'] {
   cursor: pointer;
   display: block;
   font-family: inherit;
-  font-variation-settings: 'wght' 500;
   font-weight: 500;
   line-height: 1.5;
   overflow: hidden;
@@ -498,7 +489,6 @@ div[role='banner'] {
   font: initial;
   font-family: var(--ifm-heading-font-family);
   font-size: 1.125rem;
-  font-variation-settings: 'wght' 700;
   font-weight: 700;
 }
 
@@ -533,7 +523,6 @@ div[role='banner'] {
   border-radius: 1.75rem;
   color: var(--ps-action-navigation);
   font-size: 0.875rem;
-  font-variation-settings: 'wght' 500;
   font-weight: 500;
   padding-bottom: 0.2rem;
   padding-inline-end: 0.5rem;
@@ -556,8 +545,12 @@ div[class^='playgroundHeader_'] {
   color: var(--ps-text-medium) !important;
 }
 
-:is(kbd, div[class^='playgroundPreview_'] code, div[class^='playgroundPreview_']
-    kbd, div[class^='playgroundPreview_'] samp) {
+:is(
+    kbd,
+    div[class^='playgroundPreview_'] code,
+    div[class^='playgroundPreview_'] kbd,
+    div[class^='playgroundPreview_'] samp
+  ) {
   background-color: var(--ps-surface-strong);
   border: none;
   border-radius: 0.4rem;
@@ -609,7 +602,6 @@ caption {
 td {
   background-color: var(--ps-surface-weak);
   border-bottom: none !important;
-  font-variation-settings: 'wght' 500;
   font-weight: 500;
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
closes #1068 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
- updates DT typography to remove `font-variation-settings` from normalize setup
- updates PS font to use correct naming for both base and Italic fonts
- removes unused code fonts to help performance loading
- adds missing Display styles

## Other information
Moz dev now recommends to only use `font-weight` and never use FVS property (it now says is too low level and may cause issues which is what we are seeing from Safari).

HS updates will come in next PR.

Sandbox: https://codesandbox.io/s/ps-react-typescript-forked-dke59m?file=/src/App.tsx