### PR TITLE
[Feature]: call setupFocusTrap inside useFocusTrap hook

### DIFF
--- a/packages/headless-styles/sandbox/src/components/ConfirmDialog.jsx
+++ b/packages/headless-styles/sandbox/src/components/ConfirmDialog.jsx
@@ -21,7 +21,7 @@ function ConfirmAlert(props, triggerRef) {
   const wrapperRef = useRef(null)
   const confirm = getConfirmDialogProps(confirmProps)
   const isDestructive = confirmProps.kind === 'destructive'
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
 
   function handleBackdropClick(event) {
     event.stopPropagation()
@@ -31,10 +31,6 @@ function ConfirmAlert(props, triggerRef) {
   }
 
   useEscToClose(onClose)
-
-  useEffect(() => {
-    setupFocusTrap()
-  }, [setupFocusTrap])
 
   return (
     <div {...confirm.backdrop}>
@@ -82,7 +78,7 @@ function ConfirmAlertJS(props, triggerRef) {
   const wrapperRefJS = useRef(null)
   const confirm = getJSConfirmDialogProps(confirmProps)
   const isDestructive = confirmProps.kind === 'destructive'
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
 
   function handleBackdropClick(event) {
     event.stopPropagation()
@@ -92,10 +88,6 @@ function ConfirmAlertJS(props, triggerRef) {
   }
 
   useEscToClose(onClose)
-
-  useEffect(() => {
-    setupFocusTrap()
-  }, [setupFocusTrap])
 
   return (
     <div style={confirm.backdrop.styles}>

--- a/packages/headless-styles/sandbox/src/components/Modal.jsx
+++ b/packages/headless-styles/sandbox/src/components/Modal.jsx
@@ -22,7 +22,7 @@ function ModalDialog(props, triggerRef) {
   const wrapperRef = useRef(null)
   const modal = getModalProps(modalProps)
   const iconButtonProps = getIconButtonProps(modal.cancelBtnOptions)
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
 
   function handleBackdropClick(event) {
     event.stopPropagation()
@@ -33,10 +33,6 @@ function ModalDialog(props, triggerRef) {
   }
 
   useEscToClose(onClose)
-
-  useEffect(() => {
-    setupFocusTrap()
-  }, [setupFocusTrap])
 
   return (
     <div {...modal.backdrop}>

--- a/packages/headless-styles/sandbox/src/components/Popover.jsx
+++ b/packages/headless-styles/sandbox/src/components/Popover.jsx
@@ -21,11 +21,7 @@ function PopoverEl(props) {
     isExpanded: props.expanded,
     position: props.position,
   })
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
-
-  useEffect(() => {
-    setupFocusTrap(false)
-  }, [setupFocusTrap])
+  const { ref, onKeyDown } = useFocusTrap(triggerRef, { blockScroll: false })
 
   return (
     <div {...popoverProps.wrapper}>

--- a/packages/react-utils/tests/hooks/useFocusTrap.test.tsx
+++ b/packages/react-utils/tests/hooks/useFocusTrap.test.tsx
@@ -63,7 +63,7 @@ describe('useFocusTrap', () => {
   function AlertDialog(props: AlertProps) {
     const { onClose } = props
     const wrapperRef = useRef(null)
-    const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(props.triggerRef)
+    const { ref, onKeyDown } = useFocusTrap(props.triggerRef)
 
     function handleBackdropClick(event: SyntheticEvent) {
       event.stopPropagation()
@@ -71,11 +71,7 @@ describe('useFocusTrap', () => {
         onClose()
       }
     }
-
-    useEffect(() => {
-      setupFocusTrap()
-    }, [setupFocusTrap])
-
+    
     useEffect(() => {
       function handleEscClose(event: KeyboardEvent) {
         if (event.key === 'Escape') {

--- a/website/docs/development/react-utils/use-focus-trap.mdx
+++ b/website/docs/development/react-utils/use-focus-trap.mdx
@@ -27,7 +27,7 @@ import { useFocusTrap } from '@pluralsight/react-utils'
 To use `useFocusTrap` you only need to pass in a `ref` Object that is attached to the Button that triggers the dialog/modal to open.
 
 ```jsx
-const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
+const { ref, onKeyDown } = useFocusTrap(triggerRef)
 ```
 
 ## Return Value
@@ -37,17 +37,15 @@ The `useFocusTrap` hook returns an Object with the following properties
 | Name           | Type                     | Description                                                                                                             |
 | -------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | ref            | `RefObject<HTMLElement>` | The `ref` to place on the container component of your dialog/modal (i.e. the element that holds the content users see). |
-| setupFocusTrap | `Function`               | A setup function to use in a `useEffect` onMount hook (i.e. empty Array of dependencies)                                |
 | onKeyDown      | `Function`               | An event handler to place on the container component of your dialog/modal via the `onKeyDown` property.                 |
 
 ## Ignoring Scroll Blocking
 
-By nature, this hook will block background scrolling for better a dialog user experience. If you would like to opt-out of that feature, just pass `false` to the `setupFocusTrap` callback.
+By nature, this hook will block background scrolling for better a dialog user experience. If you would like to opt-out of that feature, just pass `{ blockScroll: false }` to the second argument of the hook.
 
 ```jsx showLineNumbers
-useEffect(() => {
-  setupFocusTrap(false)
-}, [setupFocusTrap])
+const { ref, onKeyDown } = useFocusTrap(triggerRef, {blockScroll: false})
+
 ```
 
 ## Example usage in Component
@@ -72,7 +70,7 @@ function AlertDialog(props, triggerRef) {
     primary: alert.primaryBtnOptions,
   })
   // highlight-next-line
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
 
   function handleBackdropClick(event) {
     event.stopPropagation()
@@ -82,12 +80,6 @@ function AlertDialog(props, triggerRef) {
   }
 
   useEscToClose(onClose)
-
-  useEffect(() => {
-    // highlight-next-line
-    setupFocusTrap()
-  }, [setupFocusTrap])
-
   return (
     <div {...alert.backdrop}>
       <div {...alert.focusGuard} />

--- a/website/src/components/ConfirmDialog/BasicConfirmDialog.preview.js
+++ b/website/src/components/ConfirmDialog/BasicConfirmDialog.preview.js
@@ -37,7 +37,7 @@ function ConfirmDialogEl(props, triggerRef) {
   const { onClose, ...confirmProps } = props
   const wrapperRef = useRef(null)
   const confirm = getConfirmDialogProps(confirmProps)
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
   const isDestructive = confirmProps.kind === 'destructive'
 
   function handleBackdropClick(event) {
@@ -48,10 +48,6 @@ function ConfirmDialogEl(props, triggerRef) {
   }
 
   useEscToClose(onClose)
-
-  useEffect(() => {
-    setupFocusTrap()
-  }, [setupFocusTrap])
 
   return (
     <div {...confirm.backdrop}>

--- a/website/src/components/ConfirmDialog/ConfirmDialog.js
+++ b/website/src/components/ConfirmDialog/ConfirmDialog.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, memo, useEffect, useRef } from 'react'
+import React, { forwardRef, memo, useRef } from 'react'
 import { useEscToClose, useFocusTrap } from '@pluralsight/react-utils'
 import {
   getButtonProps,
@@ -11,7 +11,7 @@ function ConfirmDialogEl(props, triggerRef) {
   const { onClose, ...confirmProps } = props
   const wrapperRef = useRef(null)
   const confirm = getConfirmDialogProps(confirmProps)
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
   const isDestructive = confirmProps.kind === 'destructive'
 
   function handleBackdropClick(event) {
@@ -22,10 +22,6 @@ function ConfirmDialogEl(props, triggerRef) {
   }
 
   useEscToClose(onClose)
-
-  useEffect(() => {
-    setupFocusTrap()
-  }, [setupFocusTrap])
 
   return (
     <div {...confirm.backdrop}>

--- a/website/src/components/Modal/BasicModal.preview.js
+++ b/website/src/components/Modal/BasicModal.preview.js
@@ -40,7 +40,7 @@ function ModalEl(props, triggerRef) {
   console.log(modal)
   const { button, iconOptions } = getIconButtonProps(modal.cancelBtnOptions)
   const wrapperRef = useRef(null)
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
 
   function handleBackdropClick(event) {
     event.stopPropagation()
@@ -50,10 +50,6 @@ function ModalEl(props, triggerRef) {
   }
 
   useEscToClose(onClose)
-
-  useEffect(() => {
-    setupFocusTrap()
-  }, [setupFocusTrap])
 
   return (
     <div {...modal.backdrop}>

--- a/website/src/components/Modal/Modal.js
+++ b/website/src/components/Modal/Modal.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, memo, useEffect, useRef } from 'react'
+import React, { forwardRef, memo, useRef } from 'react'
 import { useEscToClose, useFocusTrap } from '@pluralsight/react-utils'
 import {
   getIconButtonProps,
@@ -13,7 +13,7 @@ function ModalEl(props, triggerRef) {
   console.log(modal)
   const { button, iconOptions } = getIconButtonProps(modal.cancelBtnOptions)
   const wrapperRef = useRef(null)
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
 
   function handleBackdropClick(event) {
     event.stopPropagation()
@@ -23,10 +23,6 @@ function ModalEl(props, triggerRef) {
   }
 
   useEscToClose(onClose)
-
-  useEffect(() => {
-    setupFocusTrap()
-  }, [setupFocusTrap])
 
   return (
     <div {...modal.backdrop}>

--- a/website/src/components/Popover/BasicPopover.preview.js
+++ b/website/src/components/Popover/BasicPopover.preview.js
@@ -44,11 +44,7 @@ export default function Popover(props) {
     isExpanded: props.expanded,
     position: props.position,
   })
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
-
-  useEffect(() => {
-    setupFocusTrap(false)
-  }, [setupFocusTrap])
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
 
   return (
     <div {...popoverProps.wrapper}>

--- a/website/src/components/Popover/Popover.js
+++ b/website/src/components/Popover/Popover.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useRef } from 'react'
 import { useFocusTrap } from '@pluralsight/react-utils'
 import { CloseIcon } from '@pluralsight/icons'
 import {
@@ -17,11 +17,7 @@ export default function Popover(props) {
     isExpanded: props.expanded,
     position: props.position,
   })
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
-
-  useEffect(() => {
-    setupFocusTrap(false)
-  }, [setupFocusTrap])
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
 
   return (
     <div {...popoverProps.wrapper}>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
Simplify the API for useFocusTrap

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
You have to call `setupFocusTrap` after calling the hook.

## What is the new behavior?
You can pass an options argument to the hook and then you don't need to call `setupFocusTrap` manually.

## Other information
Closes #1138