### PR TITLE
fix(headless-styles): swap quotes in checkbox/radio JS APIs to match …

### DIFF
--- a/packages/headless-styles/src/components/Checkbox/checkboxJS.ts
+++ b/packages/headless-styles/src/components/Checkbox/checkboxJS.ts
@@ -8,13 +8,13 @@ export function getJSCheckboxProps(options?: CheckboxOptions) {
   const props = createCheckboxProps(defaultOptions)
   const controlStyles = {
     ...styles.checkboxControl,
-    '&[data-checked="true"]:hover': {
+    "&[data-checked='true']:hover": {
       ...styles.checkboxControl_data_checked__true['&:hover'],
     },
-    '&[data-invalid="true"]:hover': {
+    "&[data-invalid='true']:hover": {
       ...styles.checkboxControl_data_invalid__true['&:hover'],
     },
-    '&[data-readonly="true"]:hover': {
+    "&[data-readonly='true']:hover": {
       ...styles.checkboxControl_data_readonly__true['&:hover'],
     },
   }

--- a/packages/headless-styles/src/components/Radio/radioJS.ts
+++ b/packages/headless-styles/src/components/Radio/radioJS.ts
@@ -9,13 +9,13 @@ export function getJSRadioProps(options?: RadioOptions) {
   const props = createCheckboxFieldProps(defaultOptions)
   const controlStyles = {
     ...styles.radioControl,
-    '&[data-checked="true"]:hover': {
+    "&[data-checked='true']:hover": {
       ...styles.radioControl_data_checked__true['&:hover'],
     },
-    '&[data-checked="true"]::before': {
+    "&[data-checked='true']::before": {
       ...styles.radioControl_data_checked__true['&::before'],
     },
-    '&[data-invalid="true"]:hover': {
+    "&[data-invalid='true']:hover": {
       ...styles.radioControl_data_invalid__true['&:hover'],
     },
   }


### PR DESCRIPTION
…other outputs

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #1081 

## What is the new behavior?
Swaps the quotes used for the nested attribute selectors in the Radio and Checkbox JS APIs to match the generated CSS properties, which are based on our automated formatting rules

## Other information
Fork of issue sandbox with the properties updated
https://codesandbox.io/s/basic-mui-forked-szffsp?file=/src/App.tsx
