### PR TITLE
Refactor/1131 feature confirmdialog and modal should share return props

### DIFF
--- a/packages/headless-styles/src/components/ConfirmDialog/shared.ts
+++ b/packages/headless-styles/src/components/ConfirmDialog/shared.ts
@@ -32,7 +32,9 @@ export function createConfirmDialogIconProps(
   return {}
 }
 
-export function createConfirmDialogProps(options: ConfirmDialogOptions) {
+export function createConfirmDialogProps(
+  options: Required<ConfirmDialogOptions>
+) {
   const props = createDialogProps(options)
 
   return {

--- a/packages/headless-styles/src/components/ConfirmDialog/shared.ts
+++ b/packages/headless-styles/src/components/ConfirmDialog/shared.ts
@@ -1,3 +1,4 @@
+import { createDialogProps } from '../shared/helpers/dialog'
 import type { ButtonOptions } from '../Button/types'
 import type { IconPropsOptions } from '../types'
 import type { ConfirmDialogOptions } from './types'
@@ -32,41 +33,18 @@ export function createConfirmDialogIconProps(
 }
 
 export function createConfirmDialogProps(options: ConfirmDialogOptions) {
-  const { bodyId, headingId } = options
+  const props = createDialogProps(options)
 
   return {
+    ...props,
     cancelBtnOptions: {
       usage: 'outline',
     } as ButtonOptions,
     agreeBtnOptions: {
       sentiment: options.kind === 'destructive' ? 'danger' : 'action',
     } as ButtonOptions,
-    heading: {
-      id: headingId,
-    },
-    body: {
-      id: bodyId,
-    },
-    backdrop: {},
     buttonGroup: {},
     cancelButton: {},
-    focusGuard: {
-      ['data-aria-hidden']: true,
-      ['data-focus-guard']: true,
-      tabIndex: 0,
-    },
-    section: {
-      ['aria-modal']: true,
-      ['aria-describedby']: bodyId,
-      ['aria-labelledby']: headingId,
-      id: options.id,
-      role: 'alertdialog',
-      tabIndex: -1,
-    },
-    wrapper: {
-      ['data-focus-lock-disabled']: false,
-      tabIndex: -1,
-    },
     header: {},
   }
 }

--- a/packages/headless-styles/src/components/Modal/shared.ts
+++ b/packages/headless-styles/src/components/Modal/shared.ts
@@ -1,8 +1,4 @@
-import {
-  getA11yLabelContent,
-  getA11yLabelOption,
-  getDialogA11yLabel,
-} from '../../utils/a11yHelpers'
+import { createDialogProps } from '../shared/helpers/dialog'
 import type { IconButtonOptions } from '../IconButton/types'
 import type { ModalOptions } from './types'
 
@@ -15,11 +11,11 @@ export function getDefaultModalOptions(options?: ModalOptions) {
   }
 }
 
-export function createModalProps(options: ModalOptions) {
-  const { bodyId, headingId } = options
+export function createModalProps(options: Required<ModalOptions>) {
+  const props = createDialogProps(options)
 
   return {
-    backdrop: {},
+    ...props,
     cancelBtnOptions: {
       ariaLabel: 'Close dialog',
       sentiment: 'default',
@@ -27,31 +23,9 @@ export function createModalProps(options: ModalOptions) {
       size: 'l',
     } as IconButtonOptions,
     buttonWrapper: {},
-    focusGuard: {
-      'aria-hidden': true,
-      'data-focus-guard': true,
-      tabIndex: 0,
-    },
-    heading: {
-      id: headingId,
-    },
-    body: {
-      id: bodyId,
-    },
     section: {
-      'aria-modal': true,
-      'aria-describedby': bodyId,
-      ...getDialogA11yLabel(
-        getA11yLabelContent(headingId, options.ariaLabel),
-        getA11yLabelOption(headingId)
-      ),
-      id: options.id,
+      ...props.section,
       role: 'dialog',
-      tabIndex: -1,
-    },
-    wrapper: {
-      'data-focus-lock-disabled': false,
-      tabIndex: -1,
     },
   }
 }

--- a/packages/headless-styles/src/components/Popover/shared.ts
+++ b/packages/headless-styles/src/components/Popover/shared.ts
@@ -1,8 +1,4 @@
-import {
-  getA11yLabelContent,
-  getA11yLabelOption,
-  getDialogA11yLabel,
-} from '../../utils/a11yHelpers'
+import { getDialogA11yLabel } from '../../utils/a11yHelpers'
 import { getTooltipClasses } from '../shared/helpers/tooltipHelpers'
 import type { IconButtonOptions } from '../../types'
 import type { PopoverOptions } from './types'
@@ -29,15 +25,15 @@ export function getPopoverClasses(options: Required<PopoverOptions>) {
   }
 }
 
-export function createPopoverProps(options: PopoverOptions) {
+export function createPopoverProps(options: Required<PopoverOptions>) {
   return {
     wrapper: {},
     popover: {
       'aria-describedby': options.bodyId,
-      ...getDialogA11yLabel(
-        getA11yLabelContent(options.headerId, options.ariaLabel),
-        getA11yLabelOption(options.headerId)
-      ),
+      ...getDialogA11yLabel({
+        ariaLabel: options.ariaLabel,
+        headingId: options.headerId,
+      }),
       'data-expanded': options.isExpanded,
       'data-popover': true,
       id: options.id,

--- a/packages/headless-styles/src/components/shared/helpers/dialog.ts
+++ b/packages/headless-styles/src/components/shared/helpers/dialog.ts
@@ -1,0 +1,32 @@
+import type { DialogOptions } from '../../types'
+
+export function createDialogProps(options: DialogOptions) {
+  const { bodyId, headingId } = options
+
+  return {
+    body: {
+      id: bodyId,
+    },
+    backdrop: {},
+    focusGuard: {
+      'aria-hidden': true,
+      'data-focus-guard': true,
+      tabIndex: 0,
+    },
+    heading: {
+      id: headingId,
+    },
+    section: {
+      'aria-modal': true,
+      'aria-describedby': bodyId,
+      'aria-labelledby': headingId,
+      id: options.id,
+      role: 'alertdialog',
+      tabIndex: -1,
+    },
+    wrapper: {
+      'data-focus-lock-disabled': false,
+      tabIndex: -1,
+    },
+  }
+}

--- a/packages/headless-styles/src/components/shared/helpers/dialog.ts
+++ b/packages/headless-styles/src/components/shared/helpers/dialog.ts
@@ -1,3 +1,4 @@
+import { getDialogA11yLabel } from '../../../utils/a11yHelpers'
 import type { DialogOptions } from '../../types'
 
 export function createDialogProps(options: DialogOptions) {
@@ -19,10 +20,10 @@ export function createDialogProps(options: DialogOptions) {
     section: {
       'aria-modal': true,
       'aria-describedby': bodyId,
-      'aria-labelledby': headingId,
       id: options.id,
       role: 'alertdialog',
       tabIndex: -1,
+      ...getDialogA11yLabel(options),
     },
     wrapper: {
       'data-focus-lock-disabled': false,

--- a/packages/headless-styles/src/utils/a11yHelpers.ts
+++ b/packages/headless-styles/src/utils/a11yHelpers.ts
@@ -1,23 +1,16 @@
-export type DialogLabelOption = 'label' | 'labelledby'
-
-export function getA11yLabelContent(labelId?: string, label?: string) {
-  return labelId || label || ''
+export interface A11yLabelOptions {
+  ariaLabel?: string
+  headingId?: string
 }
 
-export function getA11yLabelOption(labelId?: string) {
-  return labelId ? 'labelledby' : 'label'
-}
-
-export function getDialogA11yLabel(label: string, option?: DialogLabelOption) {
-  const defaultOption = option ?? 'label'
-
-  if (defaultOption === 'labelledby') {
+export function getDialogA11yLabel(options: A11yLabelOptions) {
+  if (options?.headingId) {
     return {
-      'aria-labelledby': label,
+      'aria-labelledby': options.headingId ?? '',
     }
   }
 
   return {
-    'aria-label': label,
+    'aria-label': options.ariaLabel ?? '',
   }
 }

--- a/packages/headless-styles/tests/confirmDialog/confirmDialogCSS.test.ts
+++ b/packages/headless-styles/tests/confirmDialog/confirmDialogCSS.test.ts
@@ -37,7 +37,6 @@ describe('Confirm Dialog CSS', () => {
     section: {
       ['aria-modal']: true,
       ['aria-describedby']: '',
-      ['aria-labelledby']: '',
       id: '',
       role: 'alertdialog',
       tabIndex: -1,
@@ -51,7 +50,13 @@ describe('Confirm Dialog CSS', () => {
   }
 
   test('should allow no props to be passed in', () => {
-    expect(getConfirmDialogProps()).toEqual(result)
+    expect(getConfirmDialogProps()).toEqual({
+      ...result,
+      section: {
+        ...result.section,
+        'aria-label': '',
+      },
+    })
   })
 
   test('should accept a non-destructive kind type', () => {

--- a/packages/headless-styles/tests/confirmDialog/confirmDialogCSS.test.ts
+++ b/packages/headless-styles/tests/confirmDialog/confirmDialogCSS.test.ts
@@ -29,7 +29,7 @@ describe('Confirm Dialog CSS', () => {
       className: `${baseClass}-cancel confirmDialogCancelBtn`,
     },
     focusGuard: {
-      ['data-aria-hidden']: true,
+      ['aria-hidden']: true,
       ['data-focus-guard']: true,
       tabIndex: 0,
       className: `${baseClass}-focus-guard confirmFocusGuard`,

--- a/packages/headless-styles/tests/modal/modalCSS.test.ts
+++ b/packages/headless-styles/tests/modal/modalCSS.test.ts
@@ -75,13 +75,13 @@ describe('Modal CSS', () => {
 
   test('should accept an ariaLabel instead of headingId', () => {
     const bodyId = 'modal-body'
-    const label = 'Heading for modal'
+    const ariaLabel = 'Heading for modal'
 
     expect(
       getModalProps({
         id: 'modal-id',
-        ariaLabel: label,
-        bodyId: bodyId,
+        ariaLabel,
+        bodyId,
       })
     ).toEqual({
       ...result,
@@ -92,7 +92,7 @@ describe('Modal CSS', () => {
       section: {
         ...result.section,
         'aria-describedby': bodyId,
-        'aria-label': label,
+        'aria-label': ariaLabel,
         id: 'modal-id',
       },
     })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
closes #1131 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Updates CD and Modal APIs to use shared props

## Other information
