### PR TITLE
Fix/1154 autoformat date backspace

### DIFF
--- a/packages/react-utils/src/hooks/useAutoFormatDate.ts
+++ b/packages/react-utils/src/hooks/useAutoFormatDate.ts
@@ -85,7 +85,7 @@ export interface SanitizeOptions {
 function sanitizeDate(options: SanitizeOptions) {
   const { value } = options
   const template = getTemplate(options.pattern, options.blocks)
-  // Only allow numeric characters except "/"
+  // Only allow numeric characters
   const cleanVal = value.replace(/[^0-9]/gm, '')
 
   if (cleanVal.length === template.length + 1) {
@@ -302,9 +302,9 @@ function getISOFormatDate(value: string, pattern: Pattern) {
 
   if (value.length) {
     if (first && !second) {
-      return `${first}${delimeter}`
+      return `${first}`
     } else if (second && !last) {
-      return `${first}${delimeter}${second}${delimeter}`
+      return `${first}${delimeter}${second}`
     } else {
       return `${first}${delimeter}${second}${delimeter}${last}`
     }

--- a/packages/react-utils/tests/hooks/useAutoFormatDate.test.tsx
+++ b/packages/react-utils/tests/hooks/useAutoFormatDate.test.tsx
@@ -65,7 +65,7 @@ describe('useAutoFormatDate', () => {
     const birthdateInput = screen.getByLabelText(/birthdate/i)
     user.type(
       birthdateInput,
-      '02042000[Backspace][Backspace][Backspace][Backspace][ArrowLeft][Backspace][Backspace][ArrowLeft][Backspace][Backspace]10322022'
+      '02042000[Backspace][Backspace][Backspace][Backspace][Backspace][Backspace][Backspace][Backspace]10322022'
     )
 
     const input = await screen.findByRole(
@@ -87,7 +87,7 @@ describe('useAutoFormatDate', () => {
     const birthdateInput = screen.getByLabelText(/birthdate/i)
     user.type(
       birthdateInput,
-      '02043000[Backspace][Backspace][Backspace][Backspace][ArrowLeft][Backspace]72022'
+      '02043000[Backspace][Backspace][Backspace][Backspace][Backspace]72022'
     )
 
     const input = await screen.findByRole(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #1154 

## What is the new behavior?
Does not output the delimiter until the next block in the date has a value, effectively allowing us to backspace through the delimiter.

## Other information
[Sandbox](https://codesandbox.io/s/ps-react-typescript-forked-1380eb)
