### PR TITLE
Feat/1138 call setup focus trap internally

### DIFF
--- a/packages/headless-styles/sandbox/src/components/ConfirmDialog.jsx
+++ b/packages/headless-styles/sandbox/src/components/ConfirmDialog.jsx
@@ -21,7 +21,7 @@ function ConfirmAlert(props, triggerRef) {
   const wrapperRef = useRef(null)
   const confirm = getConfirmDialogProps(confirmProps)
   const isDestructive = confirmProps.kind === 'destructive'
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
 
   function handleBackdropClick(event) {
     event.stopPropagation()
@@ -31,10 +31,6 @@ function ConfirmAlert(props, triggerRef) {
   }
 
   useEscToClose(onClose)
-
-  useEffect(() => {
-    setupFocusTrap()
-  }, [setupFocusTrap])
 
   return (
     <div {...confirm.backdrop}>
@@ -82,7 +78,7 @@ function ConfirmAlertJS(props, triggerRef) {
   const wrapperRefJS = useRef(null)
   const confirm = getJSConfirmDialogProps(confirmProps)
   const isDestructive = confirmProps.kind === 'destructive'
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
 
   function handleBackdropClick(event) {
     event.stopPropagation()
@@ -92,10 +88,6 @@ function ConfirmAlertJS(props, triggerRef) {
   }
 
   useEscToClose(onClose)
-
-  useEffect(() => {
-    setupFocusTrap()
-  }, [setupFocusTrap])
 
   return (
     <div style={confirm.backdrop.styles}>

--- a/packages/headless-styles/sandbox/src/components/Modal.jsx
+++ b/packages/headless-styles/sandbox/src/components/Modal.jsx
@@ -22,7 +22,7 @@ function ModalDialog(props, triggerRef) {
   const wrapperRef = useRef(null)
   const modal = getModalProps(modalProps)
   const iconButtonProps = getIconButtonProps(modal.cancelBtnOptions)
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
 
   function handleBackdropClick(event) {
     event.stopPropagation()
@@ -33,10 +33,6 @@ function ModalDialog(props, triggerRef) {
   }
 
   useEscToClose(onClose)
-
-  useEffect(() => {
-    setupFocusTrap()
-  }, [setupFocusTrap])
 
   return (
     <div {...modal.backdrop}>

--- a/packages/headless-styles/sandbox/src/components/Popover.jsx
+++ b/packages/headless-styles/sandbox/src/components/Popover.jsx
@@ -21,11 +21,7 @@ function PopoverEl(props) {
     isExpanded: props.expanded,
     position: props.position,
   })
-  const { ref, onKeyDown, setupFocusTrap } = useFocusTrap(triggerRef)
-
-  useEffect(() => {
-    setupFocusTrap(false)
-  }, [setupFocusTrap])
+  const { ref, onKeyDown } = useFocusTrap(triggerRef)
 
   return (
     <div {...popoverProps.wrapper}>

--- a/packages/react-utils/src/hooks/useFocusTrap.ts
+++ b/packages/react-utils/src/hooks/useFocusTrap.ts
@@ -2,7 +2,6 @@ import {
   useCallback,
   useEffect,
   useRef,
-  useState,
   type KeyboardEvent,
   type RefObject,
 } from 'react'
@@ -16,7 +15,6 @@ export function useFocusTrap(
   options?: FocusTrapOptions
 ) {
   const defaultOptions = defaultFocusTrapOptions(options)
-  const [blockScroll, setBlockScroll] = useState(defaultOptions.blockScroll)
   const modalRef = useRef<HTMLElement>(null)
   const selectorList =
     'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
@@ -55,7 +53,7 @@ export function useFocusTrap(
   )
 
   const handleInitFocusTrap = useCallback(() => {
-    setBlockScrollAttr(blockScroll)
+    setBlockScrollAttr(defaultOptions.blockScroll)
 
     if (modalRef.current != null) {
       const { firstItem } = getFocusItems()
@@ -63,12 +61,7 @@ export function useFocusTrap(
         firstItem?.focus()
       }
     }
-  }, [blockScroll, getFocusItems])
-
-  const manualInitFocusTrap = useCallback((blockScroll?: boolean) => {
-    const defaultOptions = defaultFocusTrapOptions({ blockScroll })
-    setBlockScroll(defaultOptions.blockScroll)
-  }, [])
+  }, [defaultOptions.blockScroll, getFocusItems])
 
   useEffect(() => {
     const trigger = triggerRef.current
@@ -84,7 +77,6 @@ export function useFocusTrap(
 
   return {
     ref: modalRef,
-    setupFocusTrap: manualInitFocusTrap, // deprecated
     onKeyDown: handleFocus,
   }
 }

--- a/packages/react-utils/src/hooks/useFocusTrap.ts
+++ b/packages/react-utils/src/hooks/useFocusTrap.ts
@@ -14,7 +14,7 @@ export function useFocusTrap(
   triggerRef: RefObject<HTMLButtonElement>,
   options?: FocusTrapOptions
 ) {
-  const defaultOptions = defaultFocusTrapOptions(options)
+  const defaultOptions = getDefaultFocusTrapOptions(options)
   const modalRef = useRef<HTMLElement>(null)
   const selectorList =
     'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
@@ -81,7 +81,7 @@ export function useFocusTrap(
   }
 }
 
-function defaultFocusTrapOptions(options?: FocusTrapOptions) {
+function getDefaultFocusTrapOptions(options?: FocusTrapOptions) {
   return {
     blockScroll: options?.blockScroll ?? true,
   }

--- a/packages/react-utils/src/hooks/useFocusTrap.ts
+++ b/packages/react-utils/src/hooks/useFocusTrap.ts
@@ -60,7 +60,7 @@ export function useFocusTrap(
     if (modalRef.current != null) {
       const { firstItem } = getFocusItems()
       if (document.activeElement !== firstItem) {
-        firstItem.focus()
+        firstItem?.focus()
       }
     }
   }, [blockScroll, getFocusItems])


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #1138 
closes #1200 

## What is the new behavior?
useFocusTrap calls setup internally.  

## Other information
Backwards compatibility is retained by
- adding options parameter and preserving triggerRef
- continuing to return a setup function which updates state used to control the "blockScroll" behavior 

<img width="638" alt="image" src="https://user-images.githubusercontent.com/1745718/228350429-cc844054-d7ca-4fd0-bf31-656b4e18deef.png">
(other frames are TanStack router)


[Modal sandbox](https://codesandbox.io/s/basic-modal-react-typescript-forked-pd4urn)
[Popover sandbox](https://codesandbox.io/s/basic-popover-react-typescript-forked-wzxwwr)
[Confirm Dialog sandbox](https://codesandbox.io/s/basic-confirm-dialog-react-typescript-forked-5zwewb)
