### PR TITLE
Fix/1198 a11y roles

### DIFF
--- a/packages/headless-styles/src/components/Admonition/shared.ts
+++ b/packages/headless-styles/src/components/Admonition/shared.ts
@@ -32,7 +32,7 @@ export function createAdmonitionProps() {
     textContainer: {},
     title: {},
     wrapper: {
-      role: 'alert',
+      role: 'region',
     },
   }
 }

--- a/packages/headless-styles/src/components/Checkbox/shared.ts
+++ b/packages/headless-styles/src/components/Checkbox/shared.ts
@@ -27,6 +27,7 @@ export function createCheckboxProps(options: Required<CheckboxOptions>) {
     }),
     input: {
       ...props.input,
+      ...(options.indeterminate && { 'aria-checked': 'mixed' }),
       indeterminate: options.indeterminate.toString(),
       type: 'checkbox',
     },

--- a/packages/headless-styles/src/components/CircularProgress/shared.ts
+++ b/packages/headless-styles/src/components/CircularProgress/shared.ts
@@ -5,7 +5,6 @@ import type {
   DefaultCircularProgressOptions,
 } from './types'
 
-const a11yRole = 'progressbar'
 const a11yPropMap = {
   ariaLabel: 'aria-label',
   valueMax: 'aria-valuemax',
@@ -69,7 +68,7 @@ export function getA11yCircularProgressProps(
   if (kind === 'indeterminate') {
     return {
       [a11yPropMap.ariaLabel]: a11yOptions?.ariaLabel,
-      role: a11yRole,
+      role: 'status',
     }
   }
 
@@ -78,6 +77,6 @@ export function getA11yCircularProgressProps(
     [a11yPropMap.valueMax]: a11yOptions?.max,
     [a11yPropMap.valueMin]: a11yOptions?.min,
     [a11yPropMap.valueNow]: a11yOptions?.now,
-    role: a11yRole,
+    role: 'progressbar',
   }
 }

--- a/packages/headless-styles/src/components/Pagination/shared.ts
+++ b/packages/headless-styles/src/components/Pagination/shared.ts
@@ -26,7 +26,9 @@ export function createPaginationProps(options: Required<PaginationOptions>) {
   return {
     buttonGroup: {},
     container: {},
-    text: {},
+    text: {
+      role: 'status',
+    },
     buttonOptions: createPandoOptions<ButtonOptions>({
       sentiment: 'default',
       size,

--- a/packages/headless-styles/src/components/Pagination/shared.ts
+++ b/packages/headless-styles/src/components/Pagination/shared.ts
@@ -6,6 +6,7 @@ import type { PaginationOptions } from './types'
 
 export function getDefaultPaginationOptions(options?: PaginationOptions) {
   return {
+    ariaLabel: options?.ariaLabel ?? 'Pagination',
     size: options?.size ?? 'l',
   }
 }
@@ -25,7 +26,10 @@ export function createPaginationProps(options: Required<PaginationOptions>) {
 
   return {
     buttonGroup: {},
-    container: {},
+    container: {
+      role: 'navigation',
+      'aria-label': options.ariaLabel,
+    },
     text: {
       role: 'status',
     },

--- a/packages/headless-styles/src/components/Pagination/types.ts
+++ b/packages/headless-styles/src/components/Pagination/types.ts
@@ -1,5 +1,6 @@
 import { Size } from '../types'
 
 export interface PaginationOptions {
+  ariaLabel?: string
   size?: Exclude<Size, 'xs' | 's' | 'xl' | 'xxl'>
 }

--- a/packages/headless-styles/src/components/Switch/shared.ts
+++ b/packages/headless-styles/src/components/Switch/shared.ts
@@ -41,6 +41,7 @@ export function createSwitchProps(options: Required<SwitchOptions>) {
     wrapper: {},
     input: {
       ...props.input,
+      role: 'switch',
       type: 'checkbox',
     },
     switchContainer: {},

--- a/packages/headless-styles/tests/admonition/admonitionCSS.test.ts
+++ b/packages/headless-styles/tests/admonition/admonitionCSS.test.ts
@@ -25,7 +25,7 @@ describe('Admonition CSS', () => {
     },
     wrapper: {
       className: `${baseClass} infoAdmonition`,
-      role: 'alert',
+      role: 'region',
     },
   }
 

--- a/packages/headless-styles/tests/checkbox/checkboxCSS.test.ts
+++ b/packages/headless-styles/tests/checkbox/checkboxCSS.test.ts
@@ -42,4 +42,16 @@ describe('Checkbox CSS', () => {
   test('should allow no props to be passed in', () => {
     expect(getCheckboxProps()).toEqual(result)
   })
+
+  test('should accept an indeterminate option', () => {
+    expect(
+      getCheckboxProps({
+        checked: false,
+        id: 'indeterminate-test',
+        indeterminate: true,
+        name: 'indeterminate-test',
+        value: 'indeterminate',
+      }).input['aria-checked']
+    ).toBe('mixed')
+  })
 })

--- a/packages/headless-styles/tests/checkbox/checkboxJS.test.ts
+++ b/packages/headless-styles/tests/checkbox/checkboxJS.test.ts
@@ -9,4 +9,15 @@ describe('Checkbox JS', () => {
       'center'
     )
   })
+  test('should accept an indeterminate option', () => {
+    expect(
+      getJSCheckboxProps({
+        checked: false,
+        id: 'indeterminate-test',
+        indeterminate: true,
+        name: 'indeterminate-test',
+        value: 'indeterminate',
+      }).input.a11yProps['aria-checked']
+    ).toBe('mixed')
+  })
 })

--- a/packages/headless-styles/tests/circular-progress/circularProgressCSS.test.ts
+++ b/packages/headless-styles/tests/circular-progress/circularProgressCSS.test.ts
@@ -64,7 +64,7 @@ describe('CircularProgress CSS', () => {
         ...result,
         containerProps: {
           'aria-label': ariaLabel,
-          role: 'progressbar',
+          role: 'status',
           className: `${baseClass} base`,
         },
         svgBoxProps: {

--- a/packages/headless-styles/tests/circular-progress/circularProgressJS.test.ts
+++ b/packages/headless-styles/tests/circular-progress/circularProgressJS.test.ts
@@ -44,4 +44,17 @@ describe('circular progress JS', () => {
       ]
     ).toEqual(ariaLabel)
   })
+
+  test('should return the correct ARIA role for a determinate kind', () => {
+    expect(
+      getJSCircularProgressProps({ ariaLabel }).containerProps.a11yProps.role
+    ).toEqual('progressbar')
+  })
+
+  test('should return the correct ARIA role for an indeterminate kind', () => {
+    expect(
+      getJSCircularProgressProps({ ariaLabel, kind: 'indeterminate' })
+        .containerProps.a11yProps.role
+    ).toEqual('status')
+  })
 })

--- a/packages/headless-styles/tests/pagination/paginationCSS.test.ts
+++ b/packages/headless-styles/tests/pagination/paginationCSS.test.ts
@@ -7,7 +7,9 @@ describe('Pagination CSS', () => {
       className: `${baseClass}-buttonGroup lPaginationButtonGroup`,
     },
     container: {
+      'aria-label': 'Pagination',
       className: `${baseClass} lPaginationContainer`,
+      role: 'navigation',
     },
     text: {
       className: `${baseClass}-text lPaginationText`,

--- a/packages/headless-styles/tests/pagination/paginationCSS.test.ts
+++ b/packages/headless-styles/tests/pagination/paginationCSS.test.ts
@@ -11,6 +11,7 @@ describe('Pagination CSS', () => {
     },
     text: {
       className: `${baseClass}-text lPaginationText`,
+      role: 'status',
     },
     buttonOptions: {
       sentiment: 'default',

--- a/packages/headless-styles/tests/switch/switchCSS.test.ts
+++ b/packages/headless-styles/tests/switch/switchCSS.test.ts
@@ -28,6 +28,7 @@ describe('Switch CSS', () => {
       type: 'checkbox',
       readOnly: false,
       required: false,
+      role: 'switch',
       className: `${baseClass}-input input`,
       value: '',
     },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #1198 

## What is the new behavior?
### Admonition
Changes role from `alert` to `region`
  The alert role is meant for an element that will interrupt the current reading to announce changes to its content.  
  The region role will add the admonition to the list of landmark regions

### Checkbox
Adds `aria-checked="mixed"` to indeterminate state.
  I noticed that the `indeterminate` attribute is only a JS prop and not an HTML attribute, and doesn't seem to be getting set.
  Also seems that `checked` should be false for the indeterminate state, but I'm not sure how much it matters.

### CircularProgress
Changes role to `status` for indeterminate

### Pagination
Adds `status` role to "text"
Adds `navigation` role to "container" - also adds `aria-label` and corresponding option (optional for backward compatibility)

### Switch
Adds `switch` role

## Other information
