### PR TITLE
feat(hs): add classNames option to Button

### DIFF
--- a/packages/headless-styles/src/components/Button/buttonCSS.ts
+++ b/packages/headless-styles/src/components/Button/buttonCSS.ts
@@ -23,7 +23,8 @@ export function getButtonProps(options?: ButtonOptions) {
         BTN,
         styles[usageClass],
         styles[sentimentClass],
-        styles[sizeClass]
+        styles[sizeClass],
+        ...defaultOptions.classNames
       ),
     },
   }

--- a/packages/headless-styles/src/components/Button/shared.ts
+++ b/packages/headless-styles/src/components/Button/shared.ts
@@ -25,6 +25,7 @@ export function getDefaultButtonOptions(
   options?: ButtonOptions
 ): Required<ButtonOptions> {
   return {
+    classNames: options?.classNames ?? [''],
     disabled: options?.disabled ?? false,
     icon: options?.icon ?? '',
     sentiment: options?.sentiment ?? 'action',

--- a/packages/headless-styles/src/components/Button/types.ts
+++ b/packages/headless-styles/src/components/Button/types.ts
@@ -1,6 +1,7 @@
+import type { DefaultOptions } from '../../utils/types'
 import type { Sentiment, Size, Usage } from '../types'
 
-export interface ButtonOptions {
+export interface ButtonOptions extends DefaultOptions {
   disabled?: boolean
   sentiment?: ButtonSentiment
   usage?: ButtonUsage

--- a/packages/headless-styles/src/utils/helpers.ts
+++ b/packages/headless-styles/src/utils/helpers.ts
@@ -72,7 +72,7 @@ export function createJSA11yProps(props: Record<string, unknown>) {
 }
 
 export function createClassNameProp(...classNames: string[]) {
-  return { className: classNames.join(' ') }
+  return { className: classNames.filter(Boolean).join(' ') }
 }
 
 export function createJSProps<T extends NestedGeneratedStyles>(styles: T) {

--- a/packages/headless-styles/src/utils/types.ts
+++ b/packages/headless-styles/src/utils/types.ts
@@ -4,6 +4,11 @@ import type { IconButtonOptions, IconOptions } from '../types'
 
 // interfaces
 
+export interface AllCSSProperties
+  extends CSS.Properties,
+    CSSPseudos,
+    NestedPsuedoKey {}
+
 export interface CustomA11yProps extends AllHTMLAttributes<HTMLElement> {
   'data-aria-hidden'?: boolean
   'data-checked'?: boolean
@@ -18,16 +23,15 @@ export interface CustomA11yProps extends AllHTMLAttributes<HTMLElement> {
   'data-tooltip'?: boolean
 }
 
-export interface AllCSSProperties
-  extends CSS.Properties,
-    CSSPseudos,
-    NestedPsuedoKey {}
-
 export interface CSSObj extends CSS.Properties, CSSPseudos {}
 
 export interface CSSKeyframes {
   cssProps: TemplateStringsArray
   styles: JSStyleObject
+}
+
+export interface DefaultOptions {
+  classNames?: string[]
 }
 
 export interface JSStyleProps {

--- a/packages/headless-styles/tests/button/buttonCSS.test.ts
+++ b/packages/headless-styles/tests/button/buttonCSS.test.ts
@@ -144,4 +144,14 @@ describe('Button CSS', () => {
       },
     })
   })
+
+  test('should allow a custom class name', () => {
+    expect(getButtonProps({ classNames: ['custom'] })).toEqual({
+      ...result,
+      button: {
+        ...result.button,
+        className: 'ps-btn filledButton actionButton lButton custom',
+      },
+    })
+  })
 })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
contributes #1192 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
- Adds new DefaultOptions interface
- Adds interface to ButtonOptions
- Updates ButtonCSS API to support custom classList

## Other information
We will need to refactor some APIs to be composable like the new Alert/Toast APIs for this to be beneficial.

Sandbox: https://codesandbox.io/s/ps-react-typescript-forked-g54mt8?file=/src/App.tsx