### PR TITLE
fix(hs): add has selector to skeletonCSS.module.css

### DIFF
--- a/packages/headless-styles/src/components/Skeleton/skeletonCSS.module.css
+++ b/packages/headless-styles/src/components/Skeleton/skeletonCSS.module.css
@@ -45,6 +45,6 @@
   margin-bottom: 0.5rem;
 }
 
-.content:has(button, input, textarea, select) {
+.content :is(button, input, textarea, select) {
   visibility: hidden;
 }

--- a/packages/headless-styles/src/components/Skeleton/skeletonCSS.module.css
+++ b/packages/headless-styles/src/components/Skeleton/skeletonCSS.module.css
@@ -26,6 +26,8 @@
   width: 100%;
 }
 
+/* kind */
+
 .content {
   composes: base;
 }
@@ -41,4 +43,8 @@
   composes: base;
   height: 1.25rem;
   margin-bottom: 0.5rem;
+}
+
+.content:has(button, input, textarea, select) {
+  visibility: hidden;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
contributes #1308 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Adds missing `:has` selector for the content Skeleton styles to hide non-text elements.

## Other information
https://codesandbox.io/s/ps-react-typescript-forked-bxgruz?file=/src/App.tsx