### PR TITLE
ci: don't trigger doc comment on merge_group

### DIFF
--- a/.github/workflows/contributing.yml
+++ b/.github/workflows/contributing.yml
@@ -4,7 +4,6 @@ on:
   pull_request_target:
     paths:
       - 'website/**'
-  merge_group:
   pull_request:
     paths:
       - 'website/**'


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Main build failing on this action

## What is the new behavior?
Removes the `merge_group` trigger

## Other information
