### PR TITLE
fix(hs): update Icon types to be conditional based on ariaHidden result

### DIFF
--- a/packages/headless-styles/src/components/Badge/shared.ts
+++ b/packages/headless-styles/src/components/Badge/shared.ts
@@ -11,7 +11,6 @@ export function getIconProps(
     return {
       iconOptions: createPandoOptions<IconOptions>({
         ariaHidden: true,
-        ariaLabel: '',
         customSize: '0.75rem',
       }),
       iconWrapper: {

--- a/packages/headless-styles/src/components/Icon/iconCSS.ts
+++ b/packages/headless-styles/src/components/Icon/iconCSS.ts
@@ -11,10 +11,9 @@ const ICON = 'pando-icon'
 
 export function getIconProps(options?: IconOptions) {
   const defaultOptions = getDefaultIconOptions(options)
-  const { size, ...a11y } = defaultOptions
-  const a11yProps = getA11yIconProps(a11y)
+  const a11yProps = getA11yIconProps(defaultOptions)
   const { sizeClass } = createIconSelectorClasses(
-    size,
+    defaultOptions.size,
     defaultOptions.customSize
   )
 

--- a/packages/headless-styles/src/components/Icon/shared.ts
+++ b/packages/headless-styles/src/components/Icon/shared.ts
@@ -1,10 +1,45 @@
 import type { IconSize } from '../types'
-import type { IconOptions, IconA11yOptions } from './types'
+import type { IconOptions } from './types'
+
+const WARNING =
+  'You have set ariaHidden to false, but have not provided an ariaLabel'
+
+function getIconAriaLabel(options: IconOptions) {
+  if (options.ariaHidden) {
+    return {}
+  } else if (options.ariaHidden === false && options.ariaLabel) {
+    return {
+      'aria-label': options.ariaLabel ?? '',
+    }
+  } else {
+    console.warn(WARNING)
+    return {}
+  }
+}
+
+function getIconAriaOptions(options?: IconOptions) {
+  const defaultResult = {
+    ariaHidden: true as const,
+  }
+
+  if (options?.ariaHidden) {
+    return defaultResult
+  } else if (options?.ariaHidden === false && options.ariaLabel) {
+    return {
+      ariaHidden: false as const,
+      ariaLabel: options.ariaLabel ?? '',
+    }
+  } else {
+    console.warn(WARNING)
+    return defaultResult
+  }
+}
+
+// public
 
 export function getDefaultIconOptions(options?: IconOptions) {
   return {
-    ariaHidden: options?.ariaHidden ?? false,
-    ariaLabel: options?.ariaLabel ?? 'icon',
+    ...getIconAriaOptions(options),
     classNames: options?.classNames ?? [],
     customSize: options?.customSize,
     size: options?.size ?? 'm',
@@ -21,10 +56,12 @@ export function createIconSelectorClasses(size: IconSize, customSize?: string) {
   }
 }
 
-export function getA11yIconProps(a11yOptions?: IconA11yOptions) {
+export function getA11yIconProps(options: IconOptions) {
+  const ariaLabel = getIconAriaLabel(options)
+
   return {
-    'aria-label': a11yOptions?.ariaLabel,
-    'aria-hidden': a11yOptions?.ariaHidden,
+    ...ariaLabel,
+    'aria-hidden': options.ariaHidden,
     role: 'img',
   }
 }

--- a/packages/headless-styles/src/components/Icon/types.ts
+++ b/packages/headless-styles/src/components/Icon/types.ts
@@ -1,12 +1,18 @@
 import type { DefaultOptions } from '../../utils/types'
 import type { IconSize } from '../types'
 
-export interface IconA11yOptions {
-  ariaLabel?: string
-  ariaHidden?: boolean
-}
+export type IconA11yOptions =
+  | {
+      ariaHidden?: true
+    }
+  | {
+      ariaHidden?: false
+      ariaLabel: string
+    }
 
-export interface IconOptions extends IconA11yOptions, DefaultOptions {
+export interface BaseIconOptions extends DefaultOptions {
   customSize?: string
   size?: IconSize
 }
+
+export type IconOptions = BaseIconOptions & IconA11yOptions

--- a/packages/headless-styles/src/components/IconButton/shared.ts
+++ b/packages/headless-styles/src/components/IconButton/shared.ts
@@ -45,7 +45,6 @@ export function createIconButtonProps(options: IconButtonOptions) {
   return {
     iconOptions: createPandoOptions<IconOptions>({
       ariaHidden: true,
-      ariaLabel: 'button with icon',
       size: getIconSize(options.size),
     }),
     button: {

--- a/packages/headless-styles/src/components/Input/shared.ts
+++ b/packages/headless-styles/src/components/Input/shared.ts
@@ -33,7 +33,6 @@ export function createInputClasses(options: Required<InputOptions>) {
 
 function createDefaultIconInputOptions(size: InputSize) {
   return {
-    ariaHidden: true,
     size: inputIconMap[size as keyof typeof inputIconMap] as IconSize,
   }
 }
@@ -52,6 +51,7 @@ export function createInputInvalidIconProps(
   if (invalid) {
     return {
       invalidIconOptions: createPandoOptions<IconOptions>({
+        ariaHidden: true,
         ...createDefaultIconInputOptions(options.size),
         ...additions?.invalidIconOptions,
       }),

--- a/packages/headless-styles/src/components/Select/shared.ts
+++ b/packages/headless-styles/src/components/Select/shared.ts
@@ -28,7 +28,6 @@ export function createSelectProps(options: SelectOptions) {
   const iconProps = options.invalid && {
     iconOptions: createPandoOptions<IconOptions>({
       ariaHidden: true,
-      ariaLabel: '',
       size: 'm',
     }),
     iconWrapper: {},

--- a/packages/headless-styles/tests/badge/badgeCSS.test.ts
+++ b/packages/headless-styles/tests/badge/badgeCSS.test.ts
@@ -71,7 +71,6 @@ describe('Badge CSS', () => {
     expect(getBadgeIconProps('s')).toEqual({
       iconOptions: {
         ariaHidden: true,
-        ariaLabel: '',
         customSize: '0.75rem',
       },
       iconWrapper: {

--- a/packages/headless-styles/tests/badge/badgeJS.test.ts
+++ b/packages/headless-styles/tests/badge/badgeJS.test.ts
@@ -109,7 +109,6 @@ describe('Badge JS', () => {
     const props = getJSBadgeIconProps('s')
     expect(props.iconOptions).toMatchObject({
       ariaHidden: true,
-      ariaLabel: '',
       customSize: '0.75rem',
     })
     expect(props?.iconWrapper?.cssProps).toContain('display: flex')

--- a/packages/headless-styles/tests/icon/iconCSS.test.ts
+++ b/packages/headless-styles/tests/icon/iconCSS.test.ts
@@ -3,8 +3,7 @@ import { getIconProps } from '../../src'
 describe('Icon CSS', () => {
   const baseClass = 'pando-icon'
   const result = {
-    'aria-hidden': false,
-    'aria-label': 'icon',
+    'aria-hidden': true,
     className: `${baseClass} pando_mIconSize`,
     role: 'img',
   }
@@ -34,21 +33,18 @@ describe('Icon CSS', () => {
     })
   })
 
-  test('should accept an ariaLabel', () => {
-    expect(getIconProps({ ariaLabel: 'my label' })).toEqual({
+  test('should accept an ariaLabel when not hidden', () => {
+    expect(getIconProps({ ariaHidden: false, ariaLabel: 'my label' })).toEqual({
       ...result,
+      'aria-hidden': false,
       'aria-label': 'my label',
     })
   })
 
-  test('should accept an ariaHidden flag', () => {
+  test('should not accept an ariaLabel if hidden', () => {
     expect(getIconProps({ ariaHidden: true })).toEqual({
       ...result,
       'aria-hidden': true,
-    })
-    expect(getIconProps({ ariaHidden: false })).toEqual({
-      ...result,
-      'aria-hidden': false,
     })
   })
 

--- a/packages/headless-styles/tests/icon/iconJS.test.ts
+++ b/packages/headless-styles/tests/icon/iconJS.test.ts
@@ -3,8 +3,6 @@ import type { IconSize } from '../../src/components/types'
 
 describe('icon JS', () => {
   const baseA11yProps = {
-    'aria-hidden': false,
-    'aria-label': 'icon',
     role: 'img',
   }
   const sizes: Record<IconSize, string> = {
@@ -50,11 +48,12 @@ describe('icon JS', () => {
     const customLabel = 'custom label'
     const a11yProps = {
       ...baseA11yProps,
+      'aria-hidden': false,
       'aria-label': customLabel,
     }
-    expect(getJSIconProps({ ariaLabel: customLabel }).a11yProps).toEqual(
-      a11yProps
-    )
+    expect(
+      getJSIconProps({ ariaHidden: false, ariaLabel: customLabel }).a11yProps
+    ).toEqual(a11yProps)
   })
 
   test('should accept an ariaHidden flag', () => {

--- a/packages/headless-styles/tests/iconButton/iconButtonCSS.test.ts
+++ b/packages/headless-styles/tests/iconButton/iconButtonCSS.test.ts
@@ -4,7 +4,6 @@ describe('IconButton CSS', () => {
   const result = {
     iconOptions: {
       ariaHidden: true,
-      ariaLabel: 'button with icon',
       size: 'm',
     },
     button: {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
closes #1383 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Updates Icon types to conditionally use `ariaLabel` if `ariaHidden` is `false`.

## Other information
TS made me do all that strict logic in order to be valid.

https://codesandbox.io/s/ps-react-typescript-forked-p8r8oj?file=/src/App.tsx