### PR TITLE
fix(react): forwards area and areas props for grid components

### DIFF
--- a/packages/react/src/components/Grid.tsx
+++ b/packages/react/src/components/Grid.tsx
@@ -22,8 +22,9 @@ function GridEl(
   props: PropsWithChildren<GridProps>,
   ref: ForwardedRef<HTMLDivElement>
 ) {
-  const { cols, gap, rows, ...nativeProps } = props
+  const { areas, cols, gap, rows, ...nativeProps } = props
   const pandoGridProps = getGridProps({
+    areas,
     classNames: splitClassNameProp(nativeProps.className),
     cols,
     gap,
@@ -48,8 +49,9 @@ function GridItemEl(
   props: PropsWithChildren<GridItemProps>,
   ref: ForwardedRef<HTMLDivElement>
 ) {
-  const { col, row, ...nativeProps } = props
+  const { area, col, row, ...nativeProps } = props
   const pandoGridItemProps = getGridItemProps({
+    area,
     classNames: splitClassNameProp(nativeProps.className),
     col,
     row,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
forwards `area` and `areas` props to HS grid item and grid APIs, respectively

## Other information
https://codesandbox.io/s/ps-react-typescript-forked-5o689z?file=/src/App.tsx
