### PR TITLE
fix(react): update tabs to only use pending state

### DIFF
--- a/packages/react/src/components/tabs.tsx
+++ b/packages/react/src/components/tabs.tsx
@@ -20,7 +20,6 @@ import {
   type ForwardedRef,
   type MouseEvent,
   useTransition,
-  useMemo,
   useRef,
   useEffect,
 } from 'react'
@@ -82,10 +81,6 @@ function TabEl(props: TabProps, ref: ForwardedRef<HTMLButtonElement>) {
     controls,
     selected: activeTab === nativeProps.value,
   })
-  const isDisabeled = useMemo(
-    () => nativeProps.disabled ?? isPending,
-    [nativeProps.disabled, isPending],
-  )
 
   function handleClick(e: MouseEvent<HTMLButtonElement>) {
     const target = e.target as HTMLButtonElement
@@ -109,13 +104,12 @@ function TabEl(props: TabProps, ref: ForwardedRef<HTMLButtonElement>) {
       {...nativeProps}
       {...pandoStyles}
       {...ariaProps}
-      disabled={isDisabeled}
       onClick={handleClick}
       ref={ref ?? tabRef}
     >
       {nativeProps.children}
 
-      <Show when={isPending && !isDisabeled}>
+      <Show when={isPending}>
         <CircularProgress ariaLabel="loading" kind="indeterminate" size="xs" />
       </Show>
     </button>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
When `disabled` is `undefined` in a Tab, the CircularProgress is still hidden because it is checking for `isPending` and `disabled`.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Updates the Tab to just use nativeProps.disabled and show CircularProgress when `isPending` only.

## Other information
