### PR TITLE
ci: kill pnpm cache

### DIFF
--- a/.github/workflows/publish_experimental_release.yml
+++ b/.github/workflows/publish_experimental_release.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'pnpm'
 
       - name: Install dependencies & build packages
         run: |

--- a/.github/workflows/publish_next_release.yml
+++ b/.github/workflows/publish_next_release.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
-          cache: 'pnpm'
 
       - name: Install & build next packages
         run: |

--- a/.github/workflows/publish_stable_releases.yml
+++ b/.github/workflows/publish_stable_releases.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'pnpm'
 
       - name: Setup npmrc
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Publish jobs failing due to npm cache expecting to find a pnpm-lock file.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Kills the cache feature since we don't want to store any lockfile other than bun in the root.

## Other information
