### PR TITLE
fix(docs): Update token naming in docs to match preset

### DIFF
--- a/docs/src/content/docs/reference/colors/neutral-palette.mdx
+++ b/docs/src/content/docs/reference/colors/neutral-palette.mdx
@@ -29,49 +29,49 @@ Use with all instances of non-interactive text
 </ColorSwatch>
 
 <ColorSwatch
-  title="text-weak"
+  title="text-100"
   description="Lowest emphasis text style"
   uses="Input placeholders, footer text, supplemental descriptions"
-  tokenName="neutral.text.weak"
+  tokenName="neutral.text.100"
 >
   <div
     class={css({
       height: '20',
       width: '40',
       borderRadius: 'md',
-      bgColor: 'neutral.text.weak',
+      bgColor: 'neutral.text.100',
     })}
   />
 </ColorSwatch>
 
 <ColorSwatch
-  title="text-medium"
+  title="text-200"
   description="More emphasis but not the highest"
   uses="Examples, important supplemental or outstanding content"
-  tokenName="neutral.text.medium"
+  tokenName="neutral.text.200"
 >
   <div
     class={css({
       height: '20',
       width: '40',
       borderRadius: 'md',
-      bgColor: 'neutral.text.medium',
+      bgColor: 'neutral.text.200',
     })}
   />
 </ColorSwatch>
 
 <ColorSwatch
-  title="text-strong"
+  title="text-300"
   description="Highest emphasis, to indicate a section heading, title, or form label"
   uses="Headings, titles, form labels"
-  tokenName="neutral.text.strong"
+  tokenName="neutral.text.300"
 >
   <div
     class={css({
       height: '20',
       width: '40',
       borderRadius: 'md',
-      bgColor: 'neutral.text.strong',
+      bgColor: 'neutral.text.300',
     })}
   />
 </ColorSwatch>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Fixes #1939 

## What is the new behavior?

Modifies docs to reflect preset naming convention for neutral text colors

## Other information

To test:
- run `bun run start:docs` to run docs on `localhost:4321`
- nav to http://localhost:4321/reference/colors/neutral-palette
Expected:
- see neutral text colors reflected 
![Screenshot of docs page with neutral text colors displayed](https://github.com/pluralsight/pando/assets/146388897/cb580b2e-715c-4813-8613-b726157ef59b)


