### PR TITLE
1926 (feat) fill out remaining neutral color tokens in docs

### DIFF
--- a/docs/src/components/ColorSwatch.astro
+++ b/docs/src/components/ColorSwatch.astro
@@ -26,7 +26,7 @@ const colorSwatchStyles = {
       bgColor: colorTokenName,
     })}
   />
-  <ul>
+  <ul aria-label="list of neutral color tokens">
     <li class={css({color: 'neutral.text.strong'})}>
       <strong>{title}</strong>
     </li>
@@ -37,7 +37,7 @@ const colorSwatchStyles = {
       Use for: {uses}
     </li>
     <li class={css({color: 'neutral.text.weak'})}>
-      Token Name: {colorTokenName}
+     <p>Token Name: <code>{colorTokenName}</code></p>
     </li>
   </ul> 
 </div>

--- a/docs/src/components/ColorSwatch.astro
+++ b/docs/src/components/ColorSwatch.astro
@@ -27,16 +27,16 @@ const colorSwatchStyles = {
     })}
   />
   <ul aria-label="list of neutral color tokens">
-    <li class={css({color: 'neutral.text.strong'})}>
+    <li class={css({color: 'neutral.text.300'})}>
       <strong>{title}</strong>
     </li>
     {description && <li>
       {description}
     </li>}
-    <li class={css({color: 'neutral.text.weak'})}>
+    <li class={css({color: 'neutral.text.100'})}>
       Use for: {uses}
     </li>
-    <li class={css({color: 'neutral.text.weak'})}>
+    <li class={css({color: 'neutral.text.100'})}>
      <p>Token Name: <code>{colorTokenName}</code></p>
     </li>
   </ul> 

--- a/docs/src/components/ColorSwatch.astro
+++ b/docs/src/components/ColorSwatch.astro
@@ -12,6 +12,12 @@ interface Props {
 
 const {title, description, uses, tokenName} = Astro.props;
 
+export const colorSwatchStyles = {
+      height: '20',
+      width: '40',
+      borderRadius: 'md',
+    }
+
 ---
 
 <div class={flex({flexDir: 'row', alignItems: 'center', gap: '3'})}>

--- a/docs/src/components/ColorSwatch.astro
+++ b/docs/src/components/ColorSwatch.astro
@@ -13,10 +13,10 @@ interface Props {
 const {title, description, uses, tokenName} = Astro.props;
 
 export const colorSwatchStyles = {
-      height: '20',
-      width: '40',
-      borderRadius: 'md',
-    }
+  height: '20',
+  width: '40',
+  borderRadius: 'md',
+}
 
 ---
 

--- a/docs/src/components/ColorSwatch.astro
+++ b/docs/src/components/ColorSwatch.astro
@@ -7,12 +7,12 @@ interface Props {
   title: string;
   description?: string;
   uses: string;
-  tokenName: string;
+  colorTokenName: string;
 }
 
-const {title, description, uses, tokenName} = Astro.props;
+const {title, description, uses, colorTokenName} = Astro.props;
 
-export const colorSwatchStyles = {
+const colorSwatchStyles = {
   height: '20',
   width: '20',
   borderRadius: 'md',
@@ -21,7 +21,11 @@ export const colorSwatchStyles = {
 ---
 
 <div class={flex({flexDir: 'row', alignItems: 'center', gap: '3'})}>
-  <slot />
+  <div
+    class={css(colorSwatchStyles, {
+      bgColor: colorTokenName,
+    })}
+  />
   <ul>
     <li class={css({color: 'neutral.text.strong'})}>
       <strong>{title}</strong>
@@ -33,7 +37,7 @@ export const colorSwatchStyles = {
       Use for: {uses}
     </li>
     <li class={css({color: 'neutral.text.weak'})}>
-      Token Name: {tokenName}
+      Token Name: {colorTokenName}
     </li>
   </ul> 
 </div>

--- a/docs/src/components/ColorSwatch.astro
+++ b/docs/src/components/ColorSwatch.astro
@@ -14,7 +14,7 @@ const {title, description, uses, tokenName} = Astro.props;
 
 export const colorSwatchStyles = {
   height: '20',
-  width: '40',
+  width: '20',
   borderRadius: 'md',
 }
 

--- a/docs/src/components/ColorSwatch.astro
+++ b/docs/src/components/ColorSwatch.astro
@@ -2,12 +2,13 @@
 
 import {css} from 'styled-system/css';
 import {flex} from 'styled-system/patterns'
+import {type Token} from '@pluralsight/panda-preset'
 
 interface Props {
   title: string;
   description?: string;
   uses: string;
-  colorTokenName: string;
+  colorTokenName: Token['base'];
 }
 
 const {title, description, uses, colorTokenName} = Astro.props;

--- a/docs/src/content/docs/reference/colors/neutral-palette.mdx
+++ b/docs/src/content/docs/reference/colors/neutral-palette.mdx
@@ -5,10 +5,7 @@ hero:
   tagline: 'A neutral palette for non-interactive elements and backgrounds.'
 ---
 
-import ColorSwatch, {
-  colorSwatchStyles,
-} from 'src/components/ColorSwatch.astro'
-import { css } from 'styled-system/css'
+import ColorSwatch from 'src/components/ColorSwatch.astro'
 
 ## Text colors
 
@@ -18,65 +15,35 @@ Use with all instances of non-interactive text
   title="text-initial"
   description="Default baseline text style."
   uses="Body Copy, lists"
-  tokenName="neutral.text.initial"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.text.initial',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.text.initial"
+/>
 
 <ColorSwatch
   title="text-100"
   description="Lowest emphasis text style"
   uses="Input placeholders, footer text, supplemental descriptions"
-  tokenName="neutral.text.100"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.text.100',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.text.100"
+/>
 
 <ColorSwatch
   title="text-200"
   description="More emphasis but not the highest"
   uses="Examples, important supplemental or outstanding content"
-  tokenName="neutral.text.200"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.text.200',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.text.200"
+/>
 
 <ColorSwatch
   title="text-300"
   description="Highest emphasis, to indicate a section heading, title, or form label"
   uses="Headings, titles, form labels"
-  tokenName="neutral.text.300"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.text.300',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.text.300"
+/>
 
 <ColorSwatch
   title="text-inverse"
   uses="Button icons, Tooltips"
-  tokenName="neutral.text.inverse"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.text.inverse',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.text.inverse"
+/>
 
 ## Border colors
 
@@ -86,38 +53,20 @@ All borders of non-interactive elements
   title="border-initial"
   description="Default baseline border"
   uses="most cases, e.g. card borders"
-  tokenName="neutral.border.initial"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.border.initial',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.border.initial"
+/>
 
 <ColorSwatch
   title="border-100"
   uses="Section breaks and horizontal rules"
-  tokenName="neutral.border.100"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.border.100',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.border.100"
+/>
 
 <ColorSwatch
   title="border-200"
   uses="Card border hover state"
-  tokenName="neutral.border.100"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.border.200',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.border.100"
+/>
 
 ## Background colors
 
@@ -127,14 +76,8 @@ All color fills of non-interactive elements like avatar, skeleton, or progress
   title="background"
   description="Backgrounds for non-interactive structural elements"
   uses="content skeletons"
-  tokenName="neutral.bg.initial"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.bg.initial',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.bg.initial"
+/>
 
 ## Surface colors
 
@@ -144,63 +87,33 @@ All color fills of non-interactive areas like pages, containers, or wrappers
   title="surface-initial"
   description='Reserved for the "floor" of the page, or the lowest elevation surface'
   uses="Page backgrounds"
-  tokenName="neutral.surface.initial"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.surface.initial',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.surface.initial"
+/>
 
 <ColorSwatch
   title="surface-100"
   description='Used for navigation and "canvas" background colors'
   uses='Top and side navigation, "canvas" containers for wrapping cards'
-  tokenName="neutral.surface.100"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.surface.100',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.surface.100"
+/>
 
 <ColorSwatch
   title="surface-200"
   description="Section background colors"
   uses="Page sections that require more emphasis"
-  tokenName="neutral.surface.200"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.surface.200',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.surface.200"
+/>
 
 <ColorSwatch
   title="surface-300"
   description="Highest emphasis and contrast section background colors"
   uses="Page section backgrounds"
-  tokenName="neutral.surface.300"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.surface.300',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.surface.300"
+/>
 
 <ColorSwatch
   title="surface-inverse"
   description="Contrasting element background colors"
   uses="Tooltip"
-  tokenName="neutral.surface.inverse"
->
-  <div
-    class={css(colorSwatchStyles, {
-      bgColor: 'neutral.surface.inverse',
-    })}
-  />
-</ColorSwatch>
+  colorTokenName="neutral.surface.inverse"
+/>

--- a/docs/src/content/docs/reference/colors/neutral-palette.mdx
+++ b/docs/src/content/docs/reference/colors/neutral-palette.mdx
@@ -7,7 +7,7 @@ hero:
 
 import ColorSwatch, {
   colorSwatchStyles,
-} from '../../../../components/ColorSwatch.astro'
+} from 'src/components/ColorSwatch.astro'
 import { css } from 'styled-system/css'
 
 ## Text colors
@@ -21,8 +21,7 @@ Use with all instances of non-interactive text
   tokenName="neutral.text.initial"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.text.initial',
     })}
   />
@@ -35,8 +34,7 @@ Use with all instances of non-interactive text
   tokenName="neutral.text.100"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.text.100',
     })}
   />
@@ -49,8 +47,7 @@ Use with all instances of non-interactive text
   tokenName="neutral.text.200"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.text.200',
     })}
   />
@@ -63,8 +60,7 @@ Use with all instances of non-interactive text
   tokenName="neutral.text.300"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.text.300',
     })}
   />
@@ -76,8 +72,7 @@ Use with all instances of non-interactive text
   tokenName="neutral.text.inverse"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.text.inverse',
     })}
   />
@@ -94,8 +89,7 @@ All borders of non-interactive elements
   tokenName="neutral.border.initial"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.border.initial',
     })}
   />
@@ -107,8 +101,7 @@ All borders of non-interactive elements
   tokenName="neutral.border.100"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.border.100',
     })}
   />
@@ -120,8 +113,7 @@ All borders of non-interactive elements
   tokenName="neutral.border.100"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.border.200',
     })}
   />
@@ -138,8 +130,7 @@ All color fills of non-interactive elements like avatar, skeleton, or progress
   tokenName="neutral.bg.initial"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.bg.initial',
     })}
   />
@@ -156,8 +147,7 @@ All color fills of non-interactive areas like pages, containers, or wrappers
   tokenName="neutral.surface.initial"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.surface.initial',
     })}
   />
@@ -170,8 +160,7 @@ All color fills of non-interactive areas like pages, containers, or wrappers
   tokenName="neutral.surface.100"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.surface.100',
     })}
   />
@@ -184,8 +173,7 @@ All color fills of non-interactive areas like pages, containers, or wrappers
   tokenName="neutral.surface.200"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.surface.200',
     })}
   />
@@ -198,8 +186,7 @@ All color fills of non-interactive areas like pages, containers, or wrappers
   tokenName="neutral.surface.300"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.surface.300',
     })}
   />
@@ -212,8 +199,7 @@ All color fills of non-interactive areas like pages, containers, or wrappers
   tokenName="neutral.surface.inverse"
 >
   <div
-    class={css({
-      ...colorSwatchStyles,
+    class={css(colorSwatchStyles, {
       bgColor: 'neutral.surface.inverse',
     })}
   />

--- a/docs/src/content/docs/reference/colors/neutral-palette.mdx
+++ b/docs/src/content/docs/reference/colors/neutral-palette.mdx
@@ -144,3 +144,77 @@ All color fills of non-interactive elements like avatar, skeleton, or progress
     })}
   />
 </ColorSwatch>
+
+## Surface colors
+
+All color fills of non-interactive areas like pages, containers, or wrappers
+
+<ColorSwatch
+  title="surface-initial"
+  description='Reserved for the "floor" of the page, or the lowest elevation surface'
+  uses="Page backgrounds"
+  tokenName="neutral.surface.initial"
+>
+  <div
+    class={css({
+      ...colorSwatchStyles,
+      bgColor: 'neutral.surface.initial',
+    })}
+  />
+</ColorSwatch>
+
+<ColorSwatch
+  title="surface-100"
+  description='Used for navigation and "canvas" background colors'
+  uses='Top and side navigation, "canvas" containers for wrapping cards'
+  tokenName="neutral.surface.100"
+>
+  <div
+    class={css({
+      ...colorSwatchStyles,
+      bgColor: 'neutral.surface.100',
+    })}
+  />
+</ColorSwatch>
+
+<ColorSwatch
+  title="surface-200"
+  description="Section background colors"
+  uses="Page sections that require more emphasis"
+  tokenName="neutral.surface.200"
+>
+  <div
+    class={css({
+      ...colorSwatchStyles,
+      bgColor: 'neutral.surface.200',
+    })}
+  />
+</ColorSwatch>
+
+<ColorSwatch
+  title="surface-300"
+  description="Highest emphasis and contrast section background colors"
+  uses="Page section backgrounds"
+  tokenName="neutral.surface.300"
+>
+  <div
+    class={css({
+      ...colorSwatchStyles,
+      bgColor: 'neutral.surface.300',
+    })}
+  />
+</ColorSwatch>
+
+<ColorSwatch
+  title="surface-inverse"
+  description="Contrasting element background colors"
+  uses="Tooltip"
+  tokenName="neutral.surface.inverse"
+>
+  <div
+    class={css({
+      ...colorSwatchStyles,
+      bgColor: 'neutral.surface.inverse',
+    })}
+  />
+</ColorSwatch>

--- a/docs/src/content/docs/reference/colors/neutral-palette.mdx
+++ b/docs/src/content/docs/reference/colors/neutral-palette.mdx
@@ -5,7 +5,9 @@ hero:
   tagline: 'A neutral palette for non-interactive elements and backgrounds.'
 ---
 
-import ColorSwatch from '../../../../components/ColorSwatch.astro'
+import ColorSwatch, {
+  colorSwatchStyles,
+} from '../../../../components/ColorSwatch.astro'
 import { css } from 'styled-system/css'
 
 ## Text colors
@@ -20,9 +22,7 @@ Use with all instances of non-interactive text
 >
   <div
     class={css({
-      height: '20',
-      width: '40',
-      borderRadius: 'md',
+      ...colorSwatchStyles,
       bgColor: 'neutral.text.initial',
     })}
   />
@@ -36,9 +36,7 @@ Use with all instances of non-interactive text
 >
   <div
     class={css({
-      height: '20',
-      width: '40',
-      borderRadius: 'md',
+      ...colorSwatchStyles,
       bgColor: 'neutral.text.100',
     })}
   />
@@ -52,9 +50,7 @@ Use with all instances of non-interactive text
 >
   <div
     class={css({
-      height: '20',
-      width: '40',
-      borderRadius: 'md',
+      ...colorSwatchStyles,
       bgColor: 'neutral.text.200',
     })}
   />
@@ -68,9 +64,7 @@ Use with all instances of non-interactive text
 >
   <div
     class={css({
-      height: '20',
-      width: '40',
-      borderRadius: 'md',
+      ...colorSwatchStyles,
       bgColor: 'neutral.text.300',
     })}
   />
@@ -83,10 +77,70 @@ Use with all instances of non-interactive text
 >
   <div
     class={css({
-      height: '20',
-      width: '40',
-      borderRadius: 'md',
+      ...colorSwatchStyles,
       bgColor: 'neutral.text.inverse',
+    })}
+  />
+</ColorSwatch>
+
+## Border colors
+
+All borders of non-interactive elements
+
+<ColorSwatch
+  title="border-initial"
+  description="Default baseline border"
+  uses="most cases, e.g. card borders"
+  tokenName="neutral.border.initial"
+>
+  <div
+    class={css({
+      ...colorSwatchStyles,
+      bgColor: 'neutral.border.initial',
+    })}
+  />
+</ColorSwatch>
+
+<ColorSwatch
+  title="border-100"
+  uses="Section breaks and horizontal rules"
+  tokenName="neutral.border.100"
+>
+  <div
+    class={css({
+      ...colorSwatchStyles,
+      bgColor: 'neutral.border.100',
+    })}
+  />
+</ColorSwatch>
+
+<ColorSwatch
+  title="border-200"
+  uses="Card border hover state"
+  tokenName="neutral.border.100"
+>
+  <div
+    class={css({
+      ...colorSwatchStyles,
+      bgColor: 'neutral.border.200',
+    })}
+  />
+</ColorSwatch>
+
+## Background colors
+
+All color fills of non-interactive elements like avatar, skeleton, or progress
+
+<ColorSwatch
+  title="background"
+  description="Backgrounds for non-interactive structural elements"
+  uses="content skeletons"
+  tokenName="neutral.bg.initial"
+>
+  <div
+    class={css({
+      ...colorSwatchStyles,
+      bgColor: 'neutral.bg.initial',
     })}
   />
 </ColorSwatch>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

fixes #1926

## What is the new behavior?

Adds remaining neutral color palette colors to the neutral color reference page

## Other information

reference [figma](https://www.figma.com/proto/uJtPfI38D9i8iQg0UGK2E0/Pando-Design-Guidelines?node-id=481-19600&starting-point-node-id=6%3A11626) to review current neutral color docs

https://github.com/pluralsight/pando/assets/146388897/2a58aa01-50c7-484e-b524-682df1f61a63



