### PR TITLE
fix: only ship refactored .ts files in react

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -53,8 +53,8 @@ export * from './components/Show'
 
 // hooks
 
-export * from './hooks/menu/useMenuTriggerInteraction'
-export * from './hooks/menu/useMenuListInteraction'
+// export * from './hooks/menu/useMenuTriggerInteraction'
+// export * from './hooks/menu/useMenuListInteraction'
 export * from './hooks/useTheme'
 
 // helpers

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -2,13 +2,26 @@ import { defineConfig } from 'tsup'
 import { modernConfig, legacyConfig } from '@pando/configs'
 
 const TEMP_ENTRY = [
-  'src/**/*.ts',
+  'src/index.ts',
+
+  'src/helpers/button.helpers.ts',
+  'src/helpers/input.helpers.ts',
+  'src/helpers/label.helpers.ts',
+
+  'src/hooks/useTheme.ts',
+  'src/hooks/helpers/themeHelpers.ts',
+
+  'src/utils/helpers.ts',
+  'src/utils/const.ts',
+
   'src/components/Button.tsx',
   'src/components/Input.tsx',
   'src/components/Label.tsx',
   'src/components/For.tsx',
   'src/components/Portal.tsx',
   'src/components/Show.tsx',
+  'src/components/shared/types.ts',
+
   'src/context/FormControl.tsx',
 ]
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
React lib still throwing errors for outdated types during refactor process
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Fine tunes temp exports for .ts files

## Other information
