### PR TITLE
1965 feat typography doc

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -87,6 +87,10 @@ export default defineConfig({
               ],
             },
             {
+              label: 'Typography',
+              link: '/reference/typography/',
+            },
+            {
               label: 'Brand Guidelines',
               link: 'https://view.ceros.com/pluralsight/brand-guidelines/p/8',
               attrs: {

--- a/docs/src/components/DocumentStatus.tsx
+++ b/docs/src/components/DocumentStatus.tsx
@@ -66,7 +66,7 @@ const generalDocs: DocumentEntry[] = [
     title: 'Typography',
     refLink:
       'https://www.figma.com/proto/uJtPfI38D9i8iQg0UGK2E0/Pando-Design-Guidelines?page-id=0%3A1&type=design&node-id=533-15987&viewport=1226%2C-14299%2C0.55&t=M7BKfoKdz6EBQ7ax-1&scaling=min-zoom&starting-point-node-id=6%3A11626',
-    status: DONE,
+    status: IN_PROGRESS,
   },
   {
     title: 'FAQ',

--- a/docs/src/components/DocumentStatus.tsx
+++ b/docs/src/components/DocumentStatus.tsx
@@ -66,7 +66,7 @@ const generalDocs: DocumentEntry[] = [
     title: 'Typography',
     refLink:
       'https://www.figma.com/proto/uJtPfI38D9i8iQg0UGK2E0/Pando-Design-Guidelines?page-id=0%3A1&type=design&node-id=533-15987&viewport=1226%2C-14299%2C0.55&t=M7BKfoKdz6EBQ7ax-1&scaling=min-zoom&starting-point-node-id=6%3A11626',
-    status: TODO,
+    status: DONE,
   },
   {
     title: 'FAQ',

--- a/docs/src/components/TypographyHeader.astro
+++ b/docs/src/components/TypographyHeader.astro
@@ -9,7 +9,7 @@ interface Props {
 const {description, textToken} = Astro.props
 
 import type { Token } from '@pluralsight/panda-preset';
-import {flex} from 'styled-system/patterns'
+import {flex} from '@/styled-system/patterns'
 
 ---
 

--- a/docs/src/components/TypographyHeader.astro
+++ b/docs/src/components/TypographyHeader.astro
@@ -18,6 +18,6 @@ import {flex} from 'styled-system/patterns'
   <span>{description}</span>
   <span>
     <strong>token usage: </strong>
-    <code>textStyle: {textToken}</code>
+    <code>textStyle: '{textToken}'</code>
   </span>
 </div>

--- a/docs/src/components/TypographyHeader.astro
+++ b/docs/src/components/TypographyHeader.astro
@@ -3,21 +3,21 @@
 interface Props {
   title: string;
   description: string;
-  token: string;
+  textToken: Token['base'];
 }
 
-const {title, description, token} = Astro.props
+const {description, textToken} = Astro.props
 
-import {css} from 'styled-system/css'
+import type { Token } from '@pluralsight/panda-preset';
 import {flex} from 'styled-system/patterns'
 
 ---
 
 <div class={flex({ flexDirection: 'column', margin: '3 0 3 0' })}>
-  <span class={css({ textStyle: token })}>{title}</span>
+  <slot />
   <span>{description}</span>
   <span>
     <strong>token usage: </strong>
-    <code>textStyle: {token}</code>
+    <code>textStyle: {textToken}</code>
   </span>
 </div>

--- a/docs/src/components/TypographyHeader.astro
+++ b/docs/src/components/TypographyHeader.astro
@@ -1,15 +1,14 @@
 ---
 
 interface Props {
-  title: string;
   description: string;
   textToken: Token['base'];
 }
 
-const {description, textToken} = Astro.props
+const { description, textToken } = Astro.props
 
 import type { Token } from '@pluralsight/panda-preset';
-import {flex} from '@/styled-system/patterns'
+import { flex } from '@/styled-system/patterns'
 
 ---
 

--- a/docs/src/components/TypographyHeader.astro
+++ b/docs/src/components/TypographyHeader.astro
@@ -1,0 +1,23 @@
+---
+
+interface Props {
+  title: string;
+  description: string;
+  token: string;
+}
+
+const {title, description, token} = Astro.props
+
+import {css} from 'styled-system/css'
+import {flex} from 'styled-system/patterns'
+
+---
+
+<div class={flex({ flexDirection: 'column', margin: '3 0 3 0' })}>
+  <span class={css({ textStyle: token })}>{title}</span>
+  <span>{description}</span>
+  <span>
+    <strong>token usage: </strong>
+    <code>textStyle: {token}</code>
+  </span>
+</div>

--- a/docs/src/content/docs/reference/typography.mdx
+++ b/docs/src/content/docs/reference/typography.mdx
@@ -54,40 +54,40 @@ Pando typography relies on the correct usage of <a href="https://developer.mozil
 (style name - font-weight font-size/line-height)
 
 <TypographyHeader
-  title="heading 1 - DemiBold 40/110"
   description="Use for top-level page headings and titles only. There should only be one of these per page."
-  token="h1"
-/>
+  textToken="h1"
+>
+  <span class={css({ textStyle: 'h1' })}>heading 1 - DemiBold 40/110</span>
+</TypographyHeader>
 
 <TypographyHeader
-  title="heading 2 - DemiBold 32/125"
   description="Section headings. Use to delineate larger sections of a pageXOffset, similar to a high-level table of contents."
-  token="h2"
-/>
+  textToken="h2"
+>
+  <span class={css({ textStyle: 'h2' })}>heading 2 - DemiBold 32/125</span>
+</TypographyHeader>
+
+<TypographyHeader description="Nested or sidebar section titles" textToken="h3">
+  <span class={css({ textStyle: 'h3' })}>heading 3 - DemiBold 24/125</span>
+</TypographyHeader>
 
 <TypographyHeader
-  title="heading 3 - DemiBold 24/125"
-  description="Section headings. Use to delineate larger sections of a pageXOffset, similar to a high-level table of contents."
-  token="h3"
-/>
-
-<TypographyHeader
-  title="heading 4 - DemiBold 18/125"
   description="Nested or sidebar section headings"
-  token="h4"
-/>
+  textToken="h4"
+>
+  <span class={css({ textStyle: 'h4' })}>heading 4 - DemiBold 18/125</span>
+</TypographyHeader>
+
+<TypographyHeader description="In-content titles or headings" textToken="h5">
+  <span class={css({ textStyle: 'h5' })}>heading 5 - DemiBold 16/150</span>
+</TypographyHeader>
 
 <TypographyHeader
-  title="heading 5 - DemiBold 16/150"
-  description="In-content titles or headings"
-  token="h5"
-/>
-
-<TypographyHeader
-  title="heading 6 - DemiBold 14/150"
   description="Small titles for use in small sections (e.g. cards or small modules)"
-  token="h6"
-/>
+  textToken="h6"
+>
+  <span class={css({ textStyle: 'h6' })}>heading 6 - DemiBold 14/150</span>
+</TypographyHeader>
 
 ## Display Headings
 

--- a/docs/src/content/docs/reference/typography.mdx
+++ b/docs/src/content/docs/reference/typography.mdx
@@ -5,7 +5,7 @@ hero:
   tagline: 'Our system of fonts, spacing, and specifications that help convey visual hierarchy throughout content.'
 ---
 
-import { css } from 'styled-system/css'
+import { css, cx } from 'styled-system/css'
 import { flex, hstack, vstack, grid, gridItem } from 'styled-system/patterns'
 import { Icon } from '@astrojs/starlight/components'
 import TypographyHeader from 'src/components/TypographyHeader.astro'
@@ -126,15 +126,58 @@ All non-heading text is based on HTML elements for the utmost accessibility. Use
     Use for user flow text that is less is less important, or in smaller
     components and tighter spaces
   </span>
-  <div className={css({ border: '1px solid neutral.border.initial' })}>
-    <p class={css({ textStyle: 'md' })}>md - Medium 16/150%</p>
+  <div
+    class={cx(
+      gridItem({
+        colSpan: 2,
+      }),
+    )}
+  >
+    <span>
+      <strong>DEFAULT</strong>
+    </span>
+    <div
+      class={grid({
+        columns: 2,
+        border: '1px solid',
+        borderColor: 'neutral.border.initial',
+        borderRadius: 'md',
+        padding: 2,
+      })}
+    >
+      <div>
+        <p class={css({ textStyle: 'md' })}>md - Medium 16/150%</p>
+        <p class={css({ whiteSpace: 'nowrap' })}>
+          Token Usage: <code>textStyle: 'md'</code>
+        </p>
+      </div>
+      <span class={css({ marginLeft: '12' })}>
+        The default font-size, use as a default UI copy size for all UI use
+        cases.
+      </span>
+    </div>
+  </div>
+  <div>
+    <p class={css({ textStyle: 'lg' })}>lg - Medium 18/150%</p>
     <p>
-      Token Usage: <code>textStyle: 'md'</code>
+      Token Usage: <code>textStyle: 'lg'</code>
     </p>
   </div>
-  <span>
-    The default font-size, use as a default UI copy size for all UI use cases.
-  </span>
+  <span>TBD</span>
+  <div>
+    <p class={css({ textStyle: 'xl' })}>xl - Medium 20/150%</p>
+    <p>
+      Token Usage: <code>textStyle: 'xl'</code>
+    </p>
+  </div>
+  <span>TBD</span>
+  <div>
+    <p class={css({ textStyle: '2xl' })}>2xl - Medium 24/150%</p>
+    <p>
+      Token Usage: <code>textStyle: '2xl'</code>
+    </p>
+  </div>
+  <span>TBD</span>
 </div>
 
 ## Color

--- a/docs/src/content/docs/reference/typography.mdx
+++ b/docs/src/content/docs/reference/typography.mdx
@@ -38,7 +38,7 @@ Pando typography relies on the correct usage of <a href="https://developer.mozil
 
 ### Headings
 
-#### Heading text is based on the browser heading elements (i.e. h1, h2, h3, etc.)
+#### Heading text is based on the HTML heading elements
 
 (style name - font-weight font-size/line-height)
 

--- a/docs/src/content/docs/reference/typography.mdx
+++ b/docs/src/content/docs/reference/typography.mdx
@@ -1,0 +1,14 @@
+---
+title: 'Typography'
+description: 'The typography system used by the Pando design system'
+hero:
+  tagline: 'Our system of fonts, spacing, and specifications that help convey visual hierarchy throughout content.'
+---
+
+import { css } from 'styled-system/css'
+
+## Font stack
+
+<h3 class={css({ fontFamily: 'sans' })}>PS TT Commons</h3>
+
+<h3 class={css({ fontFamily: 'mono' })}>DM Mono</h3>

--- a/docs/src/content/docs/reference/typography.mdx
+++ b/docs/src/content/docs/reference/typography.mdx
@@ -8,7 +8,7 @@ hero:
 import { css, cx } from 'styled-system/css'
 import { flex, hstack, vstack, grid, gridItem } from 'styled-system/patterns'
 import { Icon } from '@astrojs/starlight/components'
-import TypographyHeader from 'src/components/TypographyHeader.astro'
+import TypographyHeader from '@/src/components/TypographyHeader.astro'
 
 ## Font stack
 

--- a/docs/src/content/docs/reference/typography.mdx
+++ b/docs/src/content/docs/reference/typography.mdx
@@ -6,9 +6,101 @@ hero:
 ---
 
 import { css } from 'styled-system/css'
+import { flex, hstack, vstack } from 'styled-system/patterns'
+import { Icon } from '@astrojs/starlight/components'
+import TypographyHeader from 'src/components/TypographyHeader.astro'
 
 ## Font stack
 
-<h3 class={css({ fontFamily: 'sans' })}>PS TT Commons</h3>
+<h3 class={css({ textStyle: 'display-md' })}>PS TT Commons</h3>
 
-<h3 class={css({ fontFamily: 'mono' })}>DM Mono</h3>
+<pre>
+  <code>font-family: "PS Commons, Arial, sans-serif;"</code>
+</pre>
+
+Used for all text styles throughout the entire user interface, except code samples.
+
+<h3 class={css({ textStyle: 'mono-md', whiteSpace: 'nowrap' })}>DM Mono</h3>
+
+<pre>
+  <code>
+    font-family: "DM Mono", sfmono-regular, menlo, monaco, consalas, "Liberation
+    Mono", "Courier New", monospace;
+  </code>
+</pre>
+
+Used only for code samples and code syntax.
+
+<a
+  rel="noreferrer noopener"
+  target="_blank"
+  href="https://drive.google.com/drive/folders/1Kw9G-bsd1hFAfxcyu650R98My9S7xlb0?usp=share_link"
+  class={hstack()}
+>
+  <p>Download fonts here</p>
+  <span>
+    <Icon class={css({ marginTop: 0 })} size="1.5rem" name="external" />
+  </span>
+</a>
+
+## Usage
+
+Pando typography relies on the correct usage of <a href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals" rel="noopener noreferrer" target="_blank">text syntax</a> which will help your designs and development accessible by nature.
+
+## Headings
+
+#### Heading text is based on the browser heading elements (i.e. h1, h2, h3, etc.)
+
+(style name - font-weight font-size/line-height)
+
+<TypographyHeader
+  title="heading 1 - DemiBold 40/110"
+  description="Use for top-level page headings and titles only. There should only be one of these per page."
+  token="h1"
+/>
+
+<TypographyHeader
+  title="heading 2 - DemiBold 32/125"
+  description="Section headings. Use to delineate larger sections of a pageXOffset, similar to a high-level table of contents."
+  token="h2"
+/>
+
+<TypographyHeader
+  title="heading 3 - DemiBold 24/125"
+  description="Section headings. Use to delineate larger sections of a pageXOffset, similar to a high-level table of contents."
+  token="h3"
+/>
+
+<TypographyHeader
+  title="heading 4 - DemiBold 18/125"
+  description="Nested or sidebar section headings"
+  token="h4"
+/>
+
+<TypographyHeader
+  title="heading 5 - DemiBold 16/150"
+  description="In-content titles or headings"
+  token="h5"
+/>
+
+<TypographyHeader
+  title="heading 6 - DemiBold 14/150"
+  description="Small titles for use in small sections (e.g. cards or small modules)"
+  token="h6"
+/>
+
+## Display Headings
+
+Use display headings for large marketing or promotion-related graphics and banners.
+
+<p class={css({ textStyle: 'display-lg' })}>display large</p>
+
+<p class={css({ textStyle: 'display-md' })}>display medium</p>
+
+<p class={css({ textStyle: 'display-sm' })}>display small</p>
+
+## Non-heading text
+
+All non-heading text is based on HTML elements for the utmost accessibility. Use underline styles for linked text only.
+
+(Style name - font-weight font-size/line-height)

--- a/docs/src/content/docs/reference/typography.mdx
+++ b/docs/src/content/docs/reference/typography.mdx
@@ -14,20 +14,9 @@ import TypographyHeader from 'src/components/TypographyHeader.astro'
 
 <h3 class={css({ textStyle: 'display-md' })}>PS TT Commons</h3>
 
-<pre>
-  <code>font-family: "PS Commons, Arial, sans-serif;"</code>
-</pre>
-
 Used for all text styles throughout the entire user interface, except code samples.
 
 <h3 class={css({ textStyle: 'mono-md', whiteSpace: 'nowrap' })}>DM Mono</h3>
-
-<pre>
-  <code>
-    font-family: "DM Mono", sfmono-regular, menlo, monaco, consalas, "Liberation
-    Mono", "Courier New", monospace;
-  </code>
-</pre>
 
 Used only for code samples and code syntax.
 
@@ -35,7 +24,7 @@ Used only for code samples and code syntax.
   rel="noreferrer noopener"
   target="_blank"
   href="https://drive.google.com/drive/folders/1Kw9G-bsd1hFAfxcyu650R98My9S7xlb0?usp=share_link"
-  class={hstack()}
+  class={hstack({ paddingTop: '10' })}
 >
   <p>Download fonts here</p>
   <span>

--- a/docs/src/content/docs/reference/typography.mdx
+++ b/docs/src/content/docs/reference/typography.mdx
@@ -5,10 +5,10 @@ hero:
   tagline: 'Our system of fonts, spacing, and specifications that help convey visual hierarchy throughout content.'
 ---
 
-import { css, cx } from 'styled-system/css'
-import { flex, hstack, vstack, grid, gridItem } from 'styled-system/patterns'
+import { hstack, grid, gridItem } from 'styled-system/patterns'
 import { Icon } from '@astrojs/starlight/components'
 import TypographyHeader from '@/src/components/TypographyHeader.astro'
+import { css, cx } from '@/styled-system/css'
 
 ## Font stack
 

--- a/docs/src/content/docs/reference/typography.mdx
+++ b/docs/src/content/docs/reference/typography.mdx
@@ -94,10 +94,19 @@ Pando typography relies on the correct usage of <a href="https://developer.mozil
 Use display headings for large marketing or promotion-related graphics and banners.
 
 <p class={css({ textStyle: 'display-lg' })}>display large</p>
+<span>
+  Token usage: <code>textStyle: 'display-lg'</code>
+</span>
 
 <p class={css({ textStyle: 'display-md' })}>display medium</p>
+<span>
+  Token usage: <code>textStyle: 'display-md'</code>
+</span>
 
 <p class={css({ textStyle: 'display-sm' })}>display small</p>
+<span>
+  Token usage: <code>textStyle: 'display-sm</code>
+</span>
 
 ### Non-heading text
 

--- a/docs/src/content/docs/reference/typography.mdx
+++ b/docs/src/content/docs/reference/typography.mdx
@@ -6,7 +6,7 @@ hero:
 ---
 
 import { css } from 'styled-system/css'
-import { flex, hstack, vstack } from 'styled-system/patterns'
+import { flex, hstack, vstack, grid, gridItem } from 'styled-system/patterns'
 import { Icon } from '@astrojs/starlight/components'
 import TypographyHeader from 'src/components/TypographyHeader.astro'
 
@@ -47,7 +47,7 @@ Used only for code samples and code syntax.
 
 Pando typography relies on the correct usage of <a href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals" rel="noopener noreferrer" target="_blank">text syntax</a> which will help your designs and development accessible by nature.
 
-## Headings
+### Headings
 
 #### Heading text is based on the browser heading elements (i.e. h1, h2, h3, etc.)
 
@@ -89,7 +89,7 @@ Pando typography relies on the correct usage of <a href="https://developer.mozil
   <span class={css({ textStyle: 'h6' })}>heading 6 - DemiBold 14/150</span>
 </TypographyHeader>
 
-## Display Headings
+### Display Headings
 
 Use display headings for large marketing or promotion-related graphics and banners.
 
@@ -99,8 +99,52 @@ Use display headings for large marketing or promotion-related graphics and banne
 
 <p class={css({ textStyle: 'display-sm' })}>display small</p>
 
-## Non-heading text
+### Non-heading text
 
 All non-heading text is based on HTML elements for the utmost accessibility. Use underline styles for linked text only.
 
 (Style name - font-weight font-size/line-height)
+
+<div class={grid({ columns: 2 })}>
+  <div>
+    <p class={css({ textStyle: 'xs' })}>xs - Medium 12/150%</p>
+    <p>
+      Token Usage: <code>textStyle: 'xs'</code>
+    </p>
+  </div>
+  <span>
+    Use as the smallest UI text, mostly for copyright or boilerplate copy that
+    is not critical to the user flow.
+  </span>
+  <div>
+    <p class={css({ textStyle: 'sm' })}>sm - Medium 14/150%</p>
+    <p>
+      Token Usage: <code>textStyle: 'sm'</code>
+    </p>
+  </div>
+  <span>
+    Use for user flow text that is less is less important, or in smaller
+    components and tighter spaces
+  </span>
+  <div className={css({ border: '1px solid neutral.border.initial' })}>
+    <p class={css({ textStyle: 'md' })}>md - Medium 16/150%</p>
+    <p>
+      Token Usage: <code>textStyle: 'md'</code>
+    </p>
+  </div>
+  <span>
+    The default font-size, use as a default UI copy size for all UI use cases.
+  </span>
+</div>
+
+## Color
+
+## Measure & alignment
+
+### Line-length
+
+### Alignment
+
+### Spacing
+
+### Sizing, spacing, and aligning icons to text


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Closes #1965

## What is the new behavior?

Migrates essentially the first half of the [Typography Doc on the Figma Design Guidelines](https://www.figma.com/proto/uJtPfI38D9i8iQg0UGK2E0/Pando-Design-Guidelines?node-id=533-15987&starting-point-node-id=6%3A11626)

## Other information

The doc felt like it was getting long and I know it is a lot of content so I decided to split this migration into 2 pr's -- the next PR will finish migrating the remaining typography content as well as make sure any typography content from beta docs is covered if necessary.

https://github.com/pluralsight/pando/assets/146388897/f57c2650-2fab-47ee-b165-b3267a1e1c94


