### PR TITLE
chore: add panda generate to build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepare": "panda codegen",
     "astro": "astro",
-    "build": "astro check && astro build",
+    "build": "bun run generate:panda && astro check && astro build",
     "dev": "bun run generate:panda && astro dev",
     "generate:panda": "panda codegen",
     "lint": "eslint --ext .astro,.js,.jsx,.mjs,.ts,.tsx .",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

#1990, #1987, #1984, #1993 all attempted to fix build errors for the new docs site. This is related to that effort - the build is [not passing yet](https://github.com/pluralsight/pando/actions/runs/7481397281/job/20362907566).

## What is the new behavior?

adds panda gen to build script to avoid missing styled-system dir

## Other information
