### PR TITLE
feat(docs): content for banner on landing page

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -9,6 +9,10 @@ hero:
       link: /tutorials/getting-started/
       icon: right-arrow
       variant: primary
+banner:
+  content: |
+    Welcome to the Pando v1 docs! Pardon our dust while we build out new content. If you are still working with the beta version, 
+    <a href="https://design.pluralsight.com/">visit the beta Pando docs</a>
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components'


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

closes #2000 

## What is the new behavior?

Adds front matter to populate a banner on the v1 docs landing page

## Other information

This is the lowest weight option - it is possible to add banners to every markdown page's front matter, but it may be enough to indicate that the v1 docs are still wip on the landing page

<img width="1728" alt="homepage screenshot" src="https://github.com/pluralsight/pando/assets/146388897/66c15916-2b8e-4eba-8add-168cc2073014">


