### PR TITLE
feat(docs): add danger palette & references

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -84,6 +84,10 @@ export default defineConfig({
                   label: 'Warning Palette',
                   link: 'reference/color/warning-palette',
                 },
+                {
+                  label: 'Danger Palette',
+                  link: 'reference/color/danger-palette',
+                },
               ],
             },
             {

--- a/docs/src/components/DocumentStatus.tsx
+++ b/docs/src/components/DocumentStatus.tsx
@@ -60,7 +60,7 @@ const generalDocs: DocumentEntry[] = [
     title: 'Danger Palette',
     refLink:
       'https://www.figma.com/proto/uJtPfI38D9i8iQg0UGK2E0/Pando-Design-Guidelines?page-id=0%3A1&type=design&node-id=483-20797&viewport=1226%2C-14299%2C0.55&t=M7BKfoKdz6EBQ7ax-1&scaling=min-zoom&starting-point-node-id=6%3A11626',
-    status: TODO,
+    status: DONE,
   },
   {
     title: 'Typography',

--- a/docs/src/content/docs/explanation/color.mdx
+++ b/docs/src/content/docs/explanation/color.mdx
@@ -5,43 +5,60 @@ hero:
   tagline: Usage guidelines and naming references
 ---
 
+import { textLink } from '@/styled-system/recipes'
+import { css } from '@/styled-system/css'
+
 ## Sentiment
 
 Every color should convey a purpose, which is its sentiment
 
-### Neutral
+### <span class={css({ color: 'neutral.text.200' })}>Neutral</span>
 
-A palette for non-actionale items, eg. page content
+A palette for non-actionable items, eg. page content
 
-<a href='/reference/color/neutral-palette'>View the neutral color reference docs</a>
+<a class={textLink()} href="/reference/color/neutral-palette">
+  View the neutral color reference docs
+</a>
 
-### Action
+### <span class={css({ color: 'action.text.200' })}>Action</span>
 
 A palette that represents actionable and interactive items (eg. buttons, text links). Only used for status and feedback.
 
-<a href='/reference/color/action-palette'>View the action color reference docs</a>
+<a class={textLink()} href="/reference/color/action-palette">
+  View the action color reference docs
+</a>
 
-### Info
+### <span class={css({ color: 'info.text.200' })}>Info</span>
 
 A palette meant to communicate an informative message to the user (eg. Admonition, Toast). Only used for status and feedback.
 
-<a href='/reference/color/info-palette'>View the info color reference docs</a>
+<a class={textLink()} href="/reference/color/info-palette">
+  View the info color reference docs
+</a>
 
-### Success
+### <span class={css({ color: 'success.text.200' })}>Success</span>
 
 A palette meant to communicate a successful state to the user (eg. Admonition, Toast). Only used for status and feedback.
 
-<a href='/reference/color/success-palette'>View the success color reference docs</a>
+<a class={textLink()} href="/reference/color/success-palette">
+  View the success color reference docs
+</a>
 
-### Warning
+### <span class={css({ color: 'warning.text.200' })}>Warning</span>
 
 A palette meant to communicate a warning state to the user (eg. Admonition, Toast). Only used for status and feedback.
 
-<a href='/reference/color/warning-palette'>View the warning color reference docs</a>
+<a class={textLink()} href="/reference/color/warning-palette">
+  View the warning color reference docs
+</a>
 
-### Danger
+### <span class={css({ color: 'danger.text.200' })}>Danger</span>
 
 A palette meant to communicate a destructive action, loss of data, or required information to the user (eg. Admonition, Toast, Confirm Dialog, destructive Buttons)
+
+<a class={textLink()} href="/reference/color/danger-palette">
+  View the danger color reference docs
+</a>
 
 ## Usage
 

--- a/docs/src/content/docs/reference/color/danger-palette.mdx
+++ b/docs/src/content/docs/reference/color/danger-palette.mdx
@@ -1,0 +1,108 @@
+---
+title: 'Color - danger'
+description: "Pando's danger color palette"
+hero:
+  tagline: 'A feedback palette that helps to communicate a danger or error state to the user.'
+---
+
+import ColorSwatch, {
+  colorSwatchStyles,
+} from '@/src/components/ColorSwatch.astro'
+import { css } from '@/styled-system/css'
+
+## Text colors
+
+Use with all instances of danger status-related element text.
+
+<ColorSwatch
+  title="text-initial"
+  description="Default text inside of status elements"
+  uses="Admonition text, Toast text, Badges"
+  colorTokenName="danger.text.initial"
+>
+  <div class={css(colorSwatchStyles, { bg: 'danger.text.initial' })} />
+</ColorSwatch>
+
+<ColorSwatch
+  title="text-100"
+  description="Low emphasis text in status elements"
+  uses="Input status icons"
+  colorTokenName="danger.text.100"
+>
+  <div class={css(colorSwatchStyles, { bg: 'danger.text.100' })} />
+</ColorSwatch>
+
+<ColorSwatch
+  title="text-200"
+  description="Highest emphasis text in status elements"
+  uses="Admonition icons, Toast icons"
+  colorTokenName="danger.text.200"
+>
+  <div class={css(colorSwatchStyles, { bg: 'danger.text.200' })} />
+</ColorSwatch>
+
+<ColorSwatch
+  title="text-inverse"
+  description="Highest emphasis text in status elements"
+  uses="Danger Button text and icons"
+  colorTokenName="danger.text.inverse"
+>
+  <div class={css(colorSwatchStyles, { bg: 'danger.text.inverse' })} />
+</ColorSwatch>
+
+## Border colors
+
+All borders of non-interactive interface items
+
+<ColorSwatch
+  title="border"
+  description="Border color of danger status-related interface items"
+  uses="Admonition border, Badges"
+  colorTokenName="danger.border.initial"
+>
+  <div class={css(colorSwatchStyles, { bg: 'danger.border.initial' })} />
+</ColorSwatch>
+
+## Background colors
+
+All color fills of danger status-related elements like avatar, skeleton, or progress
+
+<ColorSwatch
+  title="background-initial"
+  description="Surface color of status elements"
+  uses="Danger Buttons"
+  colorTokenName="danger.bg.initial"
+>
+  <div class={css(colorSwatchStyles, { bg: 'danger.bg.initial' })} />
+</ColorSwatch>
+
+<ColorSwatch
+  title="background-hover"
+  description="Surface color of status elements"
+  uses="Danger Button Hover state"
+  colorTokenName="danger.bg.hover"
+>
+  <div class={css(colorSwatchStyles, { bg: 'danger.bg.hover' })} />
+</ColorSwatch>
+
+<ColorSwatch
+  title="background-active"
+  description="Surface color of status elements"
+  uses="Danger Button active state"
+  colorTokenName="danger.bg.active"
+>
+  <div class={css(colorSwatchStyles, { bg: 'danger.bg.active' })} />
+</ColorSwatch>
+
+## Surface colors
+
+All color fills of danger status-related elements like avatar, skeleton, or progress
+
+<ColorSwatch
+  title="surface"
+  description="Surface color of non-interactive status elements"
+  uses="Admonition, Toast, Badge backgrounds"
+  colorTokenName="danger.surface.initial"
+>
+  <div class={css(colorSwatchStyles, { bg: 'danger.surface.initial' })} />
+</ColorSwatch>

--- a/docs/src/content/docs/reference/color/warning-palette.mdx
+++ b/docs/src/content/docs/reference/color/warning-palette.mdx
@@ -2,7 +2,7 @@
 title: 'Color - action'
 description: "Pando's action color palette"
 hero:
-  tagline: 'A palette representing actionable and interactive elements.'
+  tagline: 'A feedback palette that helps to communicate a warning state to the user.'
 ---
 
 import ColorSwatch, {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

closes #1964 
closes #2005 (bug)

## What is the new behavior?

* Adds danger palette ref page & navigation
* Updates color titles in to a font color of each color scheme

## Other information

* This is the last color reference page - after this color will be complete, save for clarifying details for colors on specific sentiment reference pages

https://github.com/pluralsight/pando/assets/146388897/edc5f3d9-a32b-489f-a844-09c08cfdbb06

