### PR TITLE
chore: revert docs_release path change

### DIFF
--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install, build, and upload your site
         uses: withastro/action@v1
         with:
-          path: 'docs/**'
+          path: './docs'
           package-manager: bun@latest
 
   deploy:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

#2035 made to update workflow deploy had made a change to the path which [broke the build in the deploy action](https://github.com/pluralsight/pando/actions/runs/7585993793) - this reverts that change as it had not been an issue before

## What is the new behavior?

reverts to previous path

## Other information
