### PR TITLE
ci(docs): add icon build to deploy workflow

### DIFF
--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 8
+      - name: Build icons
+        run: pnpm run build:icons
       - name: Install, build, and upload your site
         uses: withastro/action@v1
         with:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

the docs deploy is still failing after https://github.com/pluralsight/pando/pull/2094 was merged with this error: `Failed to resolve entry for package "@pluralsight/icons". The package may have incorrect main/module/exports specified in its package.json.`

I resolved this locally and in the build check by running the icons build command. This includes that step in the deploy workflow.

## What is the new behavior?

## Other information
