### PR TITLE
ci(docs): additional icon build job before build and upload step

### DIFF
--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -17,7 +17,7 @@ permissions:
   actions: read
 
 jobs:
-  build:
+  build-icons:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
@@ -28,6 +28,17 @@ jobs:
           version: 8
       - name: Build icons
         run: pnpm run build:icons
+
+  build-and-upload:
+    needs: build-icons
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
       - name: Install, build, and upload your site
         uses: withastro/action@v1
         with:
@@ -35,7 +46,7 @@ jobs:
           package-manager: pnpm@latest
 
   deploy:
-    needs: build
+    needs: build-and-upload
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

#2101 tried to run the icons build script to make fix deploy error `Failed to resolve entry for package "@pluralsight/icons". The package may have incorrect main/module/exports specified in its package.json.` but did not succeed. 

## What is the new behavior?

This puts the icons build step in another job and makes the build & upload step require icons build to complete before proceeding.

## Other information
