### PR TITLE
chore(docs): update docs deploy-pages action

### DIFF
--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -59,4 +59,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v3
+        # actions/deploy-pages@v4 is pubicly available but requires actions/upload-pages-artifact@v4.
+        # withastro/action@v1 uses actions/upload-pages-artifact@v2.
+        # see https://github.com/withastro/action/pull/38 for additional details - update this action when it is possible.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Deploying docs to gh-pages with `actions/deploy-pages@v4` is failing because it requires `actions/upload-pages-artifact@v4`. Astro's action `withastro/action@v1` uses `actions/upload-pages-artifact@v2`. This modifies the deploy-pages action to v3 to hopefully resolve the deploy issue - when `withastro/action@v2` is released we can revisit deploy-pages action version.

See https://github.com/withastro/action/pull/38 for additional details

## What is the new behavior?

## Other information
