### PR TITLE
feat(docs): swap generic button with pando iconbutton component

### DIFF
--- a/docs/src/components/ReactLib/ThemeSelect/ThemeSelectButton.tsx
+++ b/docs/src/components/ReactLib/ThemeSelect/ThemeSelectButton.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from '@pluralsight/react'
+import { useTheme, IconButton } from '@pluralsight/react'
 import { SunIcon, MoonIcon } from '@pluralsight/react/icons'
 
 export default function ThemeSelectButton() {
@@ -9,13 +9,14 @@ export default function ThemeSelectButton() {
   }
 
   return (
-    <button
-      aria-label={
+    <IconButton
+      ariaLabel={
         mode == 'dark' ? 'switch to light mode' : 'switch to dark mode'
       }
+      usage="text"
       onClick={handleUpdateMode}
     >
       {mode == 'dark' ? <SunIcon /> : <MoonIcon />}
-    </button>
+    </IconButton>
   )
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

the docs `ThemeSelectButton` uses a generic button to switch light/dark mode

## What is the new behavior?

swaps generic button for use Pando's `IconButton` 

## Other information

* still observing color contrast issues with buttons, but that color work is still in progress and will be fixed when #2117 is resolved

![iconbutton](https://github.com/pluralsight/pando/assets/146388897/8ce2a6b3-501d-4ddf-a76c-df970386a7f9)
