### PR TITLE
chore: build icons in docs build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "docs"
   ],
   "scripts": {
-    "build:docs": "pnpm --filter docs run build",
+    "build:docs": "pnpm run build:icons && pnpm --filter docs run build",
     "build:icons": "pnpm --filter @pluralsight/icons run build",
     "generate:sandbox-styles": "pnpm --filter sandbox run generate:panda",
     "lint:configs": "eslint --max-warnings 0 \"./**/*.@(ts|js|cjs|mjs)\"",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

[docs deploy is failing](https://github.com/pluralsight/pando/actions/runs/8160995009/job/22308835501) because it is unable to find `@pluralsight/icons/icons.json` in the build. 

## What is the new behavior?

I think this issue may have popped up when I started using the workspace version of icons for icons.json for the categories for icon reference docs in PR #2220. This includes icons build in the docs build script to provide that dependency and hopefully fix docs deploy.

## Other information
