### PR TITLE
chore: add gh action to deploy preview

### DIFF
--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -1,0 +1,36 @@
+name: Deploy Docs PR preview
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      # Including closed allows preview to see and close the preview on PR close
+      - closed
+  # Allows you to run this workflow manually from the Actions tab on GitHub.
+  workflow_dispatch:
+
+concurrency: docs-preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install and Build
+        if: github.event.action != 'closed'
+        run: |
+          pnpm install
+          pnpm run build:docs
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./docs/dist/


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

closes #2206 

Anyone who would like to clicktest a docs pr has to pull down the branch and run locally. Our team has worked with this, but it should not be required to view changes.

## What is the new behavior?

Adds gh action `rossjrw/pr-preview-action@v1` on pr's to deploy a preview on changes to the docs site

## Other information

https://github.com/marketplace/actions/deploy-pr-preview
