### PR TITLE
2210 docs button overview content modifications

### DIFF
--- a/docs/src/components/LiveCodeExamples/LiveCodeEditor.tsx
+++ b/docs/src/components/LiveCodeExamples/LiveCodeEditor.tsx
@@ -11,11 +11,24 @@ export default function LiveCodeEditor({
   readonly noInline?: boolean // used when you want to have control over exactly what is rendered
 }) {
   return (
-    <div className={css({ paddingTop: '6', paddingBottom: '4' })}>
+    <div
+      className={css({
+        paddingTop: '6',
+        paddingBottom: '4',
+      })}
+    >
       <LiveProvider scope={scope} code={componentString} noInline={!!noInline}>
         <LivePreview />
-        <LiveEditor />
         <LiveError />
+        <LiveEditor
+          className={css({
+            maxHeight: '80',
+            overflow: 'scroll',
+            border: '1px solid',
+            borderColor: 'action.border.initial',
+            borderRadius: 'md',
+          })}
+        />
       </LiveProvider>
     </div>
   )

--- a/docs/src/content/docs/reference/components/button/overview.mdx
+++ b/docs/src/content/docs/reference/components/button/overview.mdx
@@ -18,6 +18,7 @@ prev: false
 ---
 
 import LiveButton from '@/src/components/LiveCodeExamples/Button/LiveButtonEditor.astro'
+import TextLink from '@/src/components/ReactLib/TextLink/TextLink.astro'
 import { flex } from '@/styled-system/patterns'
 import { css } from '@/styled-system/css'
 import { ExternalLinkIcon } from '@pluralsight/react/icons'
@@ -32,23 +33,195 @@ export const navLinks = {
 
 <ComponentNav links={navLinks} active="overview" />
 
-## Props
+## Description
 
-<ol class={css({ listStyleType: 'disc' })}>
-  <li>palette?: `'action' | 'neutral' | 'danger'`</li>
-  <li>usage?: `'filled' | 'outline' | 'text'`</li>
-  <li>size?: `'md' | 'lg'`</li>
-  <li>endIcon?: `ReactNode`</li>
-  <li>startIcon?: `ReactNode`</li>
-  <li>
-    Note: all native `<button />` html attributes are also available
-  </li>
+Pando's `<Button />` is an interactive element that performs an action when activated. It can be used with text and a start or end icon. It is not meant to contain only an icon. If you would like to use a Button with only an icon, please see <TextLink href='/reference/components/icon-button/overview'>IconButton</TextLink>
+
+`<Button />` has custom props as well as access to all native `<button />` attributes. <TextLink href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button">See MDN</TextLink> for more information on the native `<button />` element including attributes and behavior
+
+<p class={css({ color: 'neutral.text.200' })}>Examples: actions on a row, closing a modal, or adding a new record</p>
+
+:::note[When to use]
+
+Buttons are meant to be used to perform an action. Unless it is to move between steps of a multi-page action, avoid using `<Button />` for navigation purposes. Instead, use the <TextLink href='/reference/components/text-link/overview'>TextLink component</TextLink>.
+
+:::
+
+## Button Anatomy
+
+<ol class={css({ listStyleType: 'decimal' })}>
+  <li>Button</li>
+  <li>Start icon</li>
+  <li>Label</li>
+  <li>End icon</li>
 </ol>
+
+<LiveButton componentString={`<Button startIcon={<PlaceholderIcon />} endIcon={<PlaceholderIcon />} >Button</Button>`} />
 
 ## Import
 
-`import { Button } from '@pluralsight/react'`
+```tsx
+import { Button } from '@pluralsight/react'
+```
 
-## Live Example
+## Variations
 
-<LiveButton componentString={`<Button palette='action' usage='filled' size='lg' startIcon={<PlaceholderIcon />} endIcon={<PlaceholderIcon />}>Button text</Button>`} />
+<LiveButton
+  componentString={`
+  <>
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'action, filled, lg'}
+      >
+        <Button>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'action, start icon, lg'}
+      >
+        <Button startIcon={<PlaceholderIcon />}>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'action, end icon, lg'}
+      >
+        <Button endIcon={<PlaceholderIcon />}>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'action, filled, md'}
+      >
+        <Button size='md'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'action, start icon, md'}
+      >
+        <Button size='md' startIcon={<PlaceholderIcon />}>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'action, end icon, md'}
+      >
+        <Button size='md' endIcon={<PlaceholderIcon />}>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'action, text, lg'}
+      >
+        <Button usage='text'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'action, text, lg, start icon'}
+      >
+        <Button startIcon={<PlaceholderIcon />} usage='text'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'action, text, lg, end icon'}
+      >
+        <Button endIcon={<PlaceholderIcon />} usage='text'>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'action, text, md'}
+      >
+        <Button size='md' usage='text'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'action, text, md, start icon'}
+      >
+        <Button size='md' startIcon={<PlaceholderIcon />} usage='text'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'action, text, md, end icon'}
+      >
+        <Button size='md' endIcon={<PlaceholderIcon />} usage='text'>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'action, outline, lg'}
+      >
+        <Button usage='outline'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'action, outline, lg, start icon'}
+      >
+        <Button startIcon={<PlaceholderIcon />} usage='outline'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'action, outline, lg, end icon'}
+      >
+        <Button endIcon={<PlaceholderIcon />} usage='outline'>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'action, outline, md'}
+      >
+        <Button size='md' usage='outline'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'action, outline, md, start icon'}
+      >
+        <Button size='md' startIcon={<PlaceholderIcon />} usage='outline'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'action, outline, md, end icon'}
+      >
+        <Button size='md' endIcon={<PlaceholderIcon />} usage='outline'>Button</Button>
+      </span>
+    </div>
+
+  </>
+`}
+/>
+## Props
+
+**Default**
+
+```tsx
+  {
+    palette: 'action',
+    usage: 'filled',
+    size: 'lg',
+    endIcon: null,
+    startIcon: null
+  }
+```
+
+**All Options**
+
+Note: those denoted with `?` are optional
+
+```tsx
+  {
+    palette?: 'action' | 'neutral' | 'danger',
+    usage?: 'filled' | 'outline' | 'text',
+    size?: 'md' | 'lg',
+    endIcon?: ReactNode,
+    startIcon?: ReactNode
+  }
+```

--- a/docs/src/content/docs/reference/components/button/overview.mdx
+++ b/docs/src/content/docs/reference/components/button/overview.mdx
@@ -195,6 +195,258 @@ import { Button } from '@pluralsight/react'
       </span>
     </div>
 
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'neutral, filled, lg'}
+      >
+        <Button palette='neutral'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'neutral, start icon, lg'}
+      >
+        <Button palette='neutral' startIcon={<PlaceholderIcon />}>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'neutral, end icon, lg'}
+      >
+        <Button palette='neutral' endIcon={<PlaceholderIcon />}>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'neutral, filled, md'}
+      >
+        <Button palette='neutral' size='md'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'neutral, start icon, md'}
+      >
+        <Button palette='neutral' size='md' startIcon={<PlaceholderIcon />}>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'neutral, end icon, md'}
+      >
+        <Button palette='neutral' size='md' endIcon={<PlaceholderIcon />}>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'neutral, text, lg'}
+      >
+        <Button palette='neutral' usage='text'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'neutral, text, lg, start icon'}
+      >
+        <Button palette='neutral' startIcon={<PlaceholderIcon />} usage='text'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'neutral, text, lg, end icon'}
+      >
+        <Button palette='neutral' endIcon={<PlaceholderIcon />} usage='text'>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'neutral, text, md'}
+      >
+        <Button palette='neutral' size='md' usage='text'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'neutral, text, md, start icon'}
+      >
+        <Button palette='neutral' size='md' startIcon={<PlaceholderIcon />} usage='text'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'neutral, text, md, end icon'}
+      >
+        <Button palette='neutral' size='md' endIcon={<PlaceholderIcon />} usage='text'>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'neutral, outline, lg'}
+      >
+        <Button palette='neutral' usage='outline'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'neutral, outline, lg, start icon'}
+      >
+        <Button palette='neutral' startIcon={<PlaceholderIcon />} usage='outline'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'neutral, outline, lg, end icon'}
+      >
+        <Button palette='neutral' endIcon={<PlaceholderIcon />} usage='outline'>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'neutral, outline, md'}
+      >
+        <Button palette='neutral' size='md' usage='outline'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'neutral, outline, md, start icon'}
+      >
+        <Button palette='neutral' size='md' startIcon={<PlaceholderIcon />} usage='outline'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'neutral, outline, md, end icon'}
+      >
+        <Button palette='neutral' size='md' endIcon={<PlaceholderIcon />} usage='outline'>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'danger, filled, lg'}
+      >
+        <Button palette='danger'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'danger, start icon, lg'}
+      >
+        <Button palette='danger' startIcon={<PlaceholderIcon />}>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'danger, end icon, lg'}
+      >
+        <Button palette='danger' endIcon={<PlaceholderIcon />}>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'danger, filled, md'}
+      >
+        <Button palette='danger' size='md'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'danger, start icon, md'}
+      >
+        <Button palette='danger' size='md' startIcon={<PlaceholderIcon />}>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'danger, end icon, md'}
+      >
+        <Button palette='danger' size='md' endIcon={<PlaceholderIcon />}>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'danger, text, lg'}
+      >
+        <Button palette='danger' usage='text'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'danger, text, lg, start icon'}
+      >
+        <Button palette='danger' startIcon={<PlaceholderIcon />} usage='text'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'danger, text, lg, end icon'}
+      >
+        <Button palette='danger' endIcon={<PlaceholderIcon />} usage='text'>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'danger, text, md'}
+      >
+        <Button palette='danger' size='md' usage='text'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'danger, text, md, start icon'}
+      >
+        <Button palette='danger' size='md' startIcon={<PlaceholderIcon />} usage='text'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'danger, text, md, end icon'}
+      >
+        <Button palette='danger' size='md' endIcon={<PlaceholderIcon />} usage='text'>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'danger, outline, lg'}
+      >
+        <Button palette='danger' usage='outline'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'danger, outline, lg, start icon'}
+      >
+        <Button palette='danger' startIcon={<PlaceholderIcon />} usage='outline'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'danger, outline, lg, end icon'}
+      >
+        <Button palette='danger' endIcon={<PlaceholderIcon />} usage='outline'>Button</Button>
+      </span>
+    </div>
+
+    <div className={hstack({gap: '4'})}>
+      <span
+        data-tooltip
+        aria-label={'danger, outline, md'}
+      >
+        <Button palette='danger' size='md' usage='outline'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'danger, outline, md, start icon'}
+      >
+        <Button palette='danger' size='md' startIcon={<PlaceholderIcon />} usage='outline'>Button</Button>
+      </span>
+      <span
+        data-tooltip
+        aria-label={'danger, outline, md, end icon'}
+      >
+        <Button palette='danger' size='md' endIcon={<PlaceholderIcon />} usage='outline'>Button</Button>
+      </span>
+    </div>
+
   </>
 `}
 />

--- a/docs/src/content/docs/reference/components/button/usage.mdx
+++ b/docs/src/content/docs/reference/components/button/usage.mdx
@@ -29,17 +29,6 @@ import ComponentNav from '@/src/components/ComponentNav.astro'
 
 <ComponentNav links={navLinks} active="usage" />
 
-## Button Anatomy
-
-<ol class={css({ listStyleType: 'decimal' })}>
-  <li>Button</li>
-  <li>Start icon (optional)</li>
-  <li>Label</li>
-  <li>End icon (optional)</li>
-</ol>
-
-<LiveButton componentString={`<Button startIcon={<PlaceholderIcon />} endIcon={<PlaceholderIcon />}>Button text</Button>`} />
-
 ## Spec
 
 Always "hug contents" button widths, relative to their label.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Closes #2210

## What is the new behavior?

Modifies button overview page per docs survey feedback to the same format as #2230

## Other information

The changes to `LiveCodeEditor.tsx` are the same as in #2230, which will cause a conflict after that is merged understandably. I just wanted to include it to show that the live editor in the overview page will not be taking up 2000 miles of vertical real estate.

https://github.com/pluralsight/pando/assets/146388897/5d89f5c9-755a-48e3-88ce-407dec7ac3fd


