### PR TITLE
docs: update coming soon components to match beta

### DIFF
--- a/docs/src/content/docs/reference/available-in-v1.mdx
+++ b/docs/src/content/docs/reference/available-in-v1.mdx
@@ -166,16 +166,21 @@ We are adding components to the sandbox as they are available in v1 to provide l
 ### Coming soon
 
 <ul class={css({ listStyleType: 'disc' })}>
-  <li>AlertDialog/Modal</li>
+  <li>ActionMenu</li>
+  <li>AlertDialog</li>
+  <li>ConfirmDialog</li>
   <li>Fieldset</li>
   <li>Flex</li>
   <li>Grid</li>
   <li>Icon</li>
   <li>Menu</li>
+  <li>Modal</li>
   <li>Popover</li>
+  <li>PromptDialog</li>
   <li>Select</li>
   <li>Tabs</li>
   <li>Table</li>
+  <li>Tooltip (recipe)</li>
 </ul>
 
 ## Hooks


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The [Available in v1](https://pando.pluralsight.com/reference/available-in-v1/) doc reflected the components commented & uncommented in `/packages/react/src/index.ts`. That file does not fully reflect all components meant to be made available in v1.

## What is the new behavior?

Updates available in v1 doc to match remaining components coming soon

